### PR TITLE
fix: downgrade linha_bruta audit from fatal to warning

### DIFF
--- a/pipelines/bolsa_familia/tasks.py
+++ b/pipelines/bolsa_familia/tasks.py
@@ -484,9 +484,9 @@ def audit_wap(
         null_particao = int(null_result['null_particao'].iloc[0])
 
         if null_linha > 0:
-            raise ValueError(
-                f"Audit FAILED: partition {partition} has {null_linha} "
-                f"rows with NULL/empty linha_bruta"
+            logger.warning(
+                f"audit_wap | Partition {partition} has {null_linha} "
+                f"rows with NULL/empty linha_bruta — will be filtered by dbt"
             )
         if null_particao > 0:
             raise ValueError(
@@ -496,7 +496,7 @@ def audit_wap(
 
         logger.info(
             f"audit_wap | Partition {partition} PASSED | "
-            f"{row_count} row(s) | null_linha=0 | null_particao=0"
+            f"{row_count} row(s) | null_linha={null_linha} | null_particao=0"
         )
 
     logger.info(


### PR DESCRIPTION
DOS EOF artifacts (\x1a) in source files create phantom rows with empty linha_bruta. These are already filtered by dbt's `WHERE linha_bruta IS NOT NULL AND TRIM(linha_bruta) != ''`. The audit should warn, not block the pipeline.