### PR TITLE
fix(deploy): renomeia dbt-transform-daily para dbt-transform-prod

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -238,7 +238,7 @@ deployments:
           SIURB_PWD: "{{ $SIURB_PWD }}"
     tags: ["staging", "dbt"]
 
-  - name: dbt-transform-daily
+  - name: dbt-transform-prod
     entrypoint: pipelines/datalake/transform/dbt/flows.py:dbt_transform_flow
     parameters:
       select: "+tag:daily"


### PR DESCRIPTION
CI/CD usa `prefect deploy --name "*-prod"` para produção, mas o deployment se chamava `dbt-transform-daily`. Renomeado para `dbt-transform-prod` para seguir a convenção e ser descoberto pelo glob.