### PR TITLE
feat: add grupo (gh_evolugrupo) as 4th origin in fct_evolucoes

### DIFF
--- a/queries/models/intermediate/core/fct_evolucoes.sql
+++ b/queries/models/intermediate/core/fct_evolucoes.sql
@@ -16,6 +16,33 @@ usu as (
         'usuario' as origem_modulo
     from {{ ref('raw_evolucoes_usuarios') }}
 ),
+grupo as (
+    select
+        safe_cast(trim(pac) as int64) as id_usuario,
+        a.id_unidade,
+        e.id_profissional,
+        e.data_evolucao,
+        e.descricao_evolucao,
+        e.tipo_evolucao,
+        'grupo' as origem_modulo,
+        null as id_familia,
+        null as modulo_prontuario,
+        e.codigo_abrangencia,
+        null as id_paciente_familia,
+        e.id_evolucao_grupo,
+        e.id_atividade
+    from {{ ref('raw_evolucoes_grupo') }} e
+    left join {{ ref('raw_atividades_grupo') }} a
+        on e.id_atividade = a.id_atividade
+    cross join unnest(
+        split(replace(replace(e.lista_pacientes, '(', ''), ')', ''), ',')
+    ) as pac
+    where e.lista_pacientes != '()'
+      and e.lista_pacientes is not null
+      and e.lista_pacientes != ''
+      and trim(pac) != ''
+      and e.data_cancelamento is null
+),
 
 uniao as (
     select 
@@ -29,7 +56,9 @@ uniao as (
         null as id_familia,
         null as modulo_prontuario,
         null as codigo_abrangencia,
-        null as id_paciente_familia
+        null as id_paciente_familia,
+        null as id_evolucao_grupo,
+        null as id_atividade
     from adm
     union all
     select 
@@ -43,7 +72,9 @@ uniao as (
         id_familia,
         modulo_prontuario,
         modulo_prontuario as codigo_abrangencia,
-        id_paciente as id_paciente_familia
+        id_paciente as id_paciente_familia,
+        null as id_evolucao_grupo,
+        null as id_atividade
     from fam
     union all
     select 
@@ -57,13 +88,37 @@ uniao as (
         null as id_familia,
         null as modulo_prontuario,
         codigo_abrangencia,
-        null as id_paciente_familia
+        null as id_paciente_familia,
+        null as id_evolucao_grupo,
+        null as id_atividade
     from usu
+    union all
+    select 
+        id_usuario, 
+        id_unidade, 
+        id_profissional, 
+        data_evolucao, 
+        descricao_evolucao, 
+        tipo_evolucao, 
+        origem_modulo,
+        null as id_familia,
+        null as modulo_prontuario,
+        codigo_abrangencia,
+        null as id_paciente_familia,
+        id_evolucao_grupo,
+        id_atividade
+    from grupo
 ),
 
 final as (
     select
-        {{ dbt_utils.generate_surrogate_key(['u.id_usuario', 'u.data_evolucao', 'u.descricao_evolucao']) }} as id_evolucao_sk,
+        {{ dbt_utils.generate_surrogate_key([
+            'u.id_usuario',
+            'u.data_evolucao',
+            'u.descricao_evolucao',
+            'u.origem_modulo',
+            'u.id_evolucao_grupo'
+        ]) }} as id_evolucao_sk,
         dim_u.id_usuario_sk,
         dim_p.id_profissional_sk,
         dim_un.id_unidade_sk,
@@ -74,7 +129,9 @@ final as (
         u.id_familia,
         u.modulo_prontuario,
         u.codigo_abrangencia,
-        u.id_paciente_familia
+        u.id_paciente_familia,
+        u.id_atividade,
+        u.id_evolucao_grupo
     from uniao u
     left join {{ ref('dim_usuarios') }} dim_u on u.id_usuario = dim_u.id_usuario
     left join {{ ref('dim_profissionais') }} dim_p on u.id_profissional = dim_p.id_profissional

--- a/queries/models/intermediate/core/fct_evolucoes.yml
+++ b/queries/models/intermediate/core/fct_evolucoes.yml
@@ -4,3 +4,7 @@ models:
     columns:
       - name: id_evolucao_sk
         tests: [unique, not_null]
+      - name: id_atividade
+        description: "FK para raw_atividades_grupo (seqatigrp). Origem: módulo grupo."
+      - name: id_evolucao_grupo
+        description: "FK para raw_evolucoes_grupo (seqevogrp). Origem: módulo grupo."

--- a/queries/models/raw/prontuario_carioca_assistencia_social/_sources.yml
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/_sources.yml
@@ -64,3 +64,5 @@ sources:
         description: "Presenças de profissionais em atividades de grupo."
       - name: gh_tpatividades
         description: "Tipos de atividade (ex: Tô de Boa: Educação e Cultura)."
+      - name: gh_evolugrupo
+        description: "Evoluções registradas em atividades de grupo."

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_grupo.sql
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_grupo.sql
@@ -1,0 +1,17 @@
+-- Camada Raw: Evoluções de atividades de grupo
+with source as (
+    select
+        seqevogrp as id_evolucao_grupo,
+        seqatigrp as id_atividade,
+        seqprof as id_profissional,
+        dtevogrp as data_evolucao,
+        dscevogrp as descricao_evolucao,
+        codabagrp as codigo_abrangencia,
+        indtpevogrp as tipo_evolucao,
+        dtcancgrp as data_cancelamento,
+        dsclistpac as lista_pacientes,
+        codcboprof as cbo_profissional,
+        dscrefpres as referencia_presenca
+    from {{ source('brutos_acolherio_staging', 'gh_evolugrupo') }}
+)
+select * from source

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_grupo.yml
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_grupo.yml
@@ -1,0 +1,32 @@
+version: 2
+models:
+  - name: raw_evolucoes_grupo
+    description: "Evoluções registradas em atividades de grupo."
+    columns:
+      - name: id_evolucao_grupo
+        description: "PK da evolução de grupo (seqevogrp)."
+        tests:
+          - unique
+          - not_null
+      - name: id_atividade
+        description: "FK para raw_atividades_grupo (seqatigrp)."
+      - name: id_profissional
+        description: "FK para raw_profissionais (seqprof)."
+      - name: data_evolucao
+        description: "Data/hora da evolução."
+        tests:
+          - not_null
+      - name: descricao_evolucao
+        description: "Descrição em HTML da evolução."
+      - name: codigo_abrangencia
+        description: "Código de abrangência da evolução (ex: 23=Tô de Boa atividades, 19=SCFV)."
+      - name: tipo_evolucao
+        description: "Tipo da evolução (D=desenvolvimento, F=fechamento)."
+      - name: data_cancelamento
+        description: "Data de cancelamento da evolução (NULL se ativa)."
+      - name: lista_pacientes
+        description: "Lista CSV de IDs de pacientes vinculados à evolução."
+      - name: cbo_profissional
+        description: "CBO do profissional no momento da evolução."
+      - name: referencia_presenca
+        description: "Referência de presença (data|hora)."


### PR DESCRIPTION
## Summary

Adiciona a origem **grupo** (atividades em grupo) como a 4a origem da fct_evolucoes, expandindo o star schema de evoluções do core.

## What changed

### New raw model: raw_evolucoes_grupo
- Source: gh_evolugrupo (evoluções de atividades em grupo)
- Schema espelha a tabela raw do sistema de prontuário

### CTE grupo na fct_evolucoes
- Explode dsclistpac via UNNEST para granularidade de usuário
- Filtros aplicados:
  - dsclistpac != () — apenas registros com pacientes vinculados
  - data_cancelamento IS NULL — apenas evoluções ativas (não canceladas)

### SK expandido
- Agora inclui origem_modulo + id_evolucao_grupo para garantir unicidade entre as 4 origens

### Novas colunas
- id_atividade: identificador da atividade em grupo
- id_evolucao_grupo: identificador da evolução no módulo grupo
- origem_modulo = grupo: marcador da origem

## Impacto

- Requer full refresh na fct_evolucoes e todos os downstreams que dependem dela
- As 3 origens existentes (administrativa, familia, usuario) não foram alteradas
- A mudança é aditiva (expande granularidade, não quebra compatibilidade existente)