### PR TITLE
feat: add extrair_campos_html_evolucao macro and enrich mart_presenca_usuarios

### DIFF
--- a/queries/macros/acolherio/extrair_campos_html_evolucao.sql
+++ b/queries/macros/acolherio/extrair_campos_html_evolucao.sql
@@ -1,0 +1,52 @@
+{% macro extrair_campos_html_evolucao(
+    source_relation,
+    id_cols,
+    col_html = 'descricao_evolucao',
+    extra_where = '',
+    table_alias = 'src'
+) %}
+
+WITH {{ table_alias }} AS (
+    SELECT * FROM {{ source_relation }}
+),
+
+campos_extraidos AS (
+    SELECT
+        {{ id_cols | join(', ') }},
+        REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'<p>(.*?)</p>') AS bloco_campos,
+        REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'</p>\s*<h3>(?:OBSERVAÇÕES|CONTEÚDO E DESCRIÇÃO)</h3>\s*([\s\S]*?)$') AS observacoes,
+        REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'<h3>(.*?)</h3>') AS titulo_formulario
+    FROM {{ table_alias }}
+    WHERE {{ table_alias }}.{{ col_html }} LIKE '%<b>%'
+    {% if extra_where %}
+      AND {{ extra_where }}
+    {% endif %}
+),
+
+fields AS (
+    SELECT
+        {{ id_cols | join(', ') }},
+        titulo_formulario,
+        field,
+        observacoes
+    FROM campos_extraidos,
+    UNNEST(REGEXP_EXTRACT_ALL(bloco_campos, r'[^<]+?:?\s*<b>[^<]*</b>')) AS field
+    WHERE bloco_campos IS NOT NULL
+),
+
+evolucao_campos_extraidos AS (
+    SELECT
+        {{ id_cols | join(', ') }},
+        titulo_formulario,
+        TRIM(REGEXP_REPLACE(
+            SPLIT(field, ': <b>')[SAFE_OFFSET(0)],
+            r'^.*?>', ''
+        )) AS label,
+        TRIM(REGEXP_EXTRACT(field, r'<b>([^<]*)</b>')) AS valor,
+        observacoes
+    FROM fields
+)
+
+SELECT * FROM evolucao_campos_extraidos
+
+{% endmacro %}

--- a/queries/models/marts/atividades/mart_presenca_usuarios.sql
+++ b/queries/models/marts/atividades/mart_presenca_usuarios.sql
@@ -5,26 +5,57 @@
 with presencas as (
     select * from {{ ref('fct_presencas_usuarios') }}
 ),
+
 usuarios as (
     select * from {{ ref('dim_usuarios') }}
 ),
+
 atividades as (
     select * from {{ ref('dim_atividades_grupo') }}
 ),
+
 filtro_email as (
     select * from {{ ref('raw_sheets_filtro_email_prontuario') }}
 ),
+
 membros_atuais as (
     select id_paciente, id_familia
     from {{ ref('raw_membros_familia') }}
     where data_saida is null
     qualify row_number() over (partition by id_paciente order by data_entrada desc) = 1
 ),
+
 familia_responsavel as (
     select id_familia, upper(nome_responsavel) as nome_responsavel
     from {{ ref('dim_familias') }}
     where nome_responsavel is not null
+),
+
+evolucoes as (
+    select e.*, u.id_usuario
+    from {{ ref('fct_evolucoes') }} e
+    left join usuarios u on e.id_usuario_sk = u.id_usuario_sk
+    where e.origem_modulo = 'grupo'
+),
+
+to_de_boa_indicadores as (
+    select
+        ie.id_evolucao_sk,
+        max(case when ie.titulo_formulario = 'Tô de Boa - Desligamento'
+                 and ie.label = 'Motivo do desligamento' then ie.valor end) as motivo_desligamento,
+        max(case when ie.titulo_formulario = 'Tô de Boa - Cancelamento das atividades'
+                 and ie.label = 'Motivo do cancelamento' then ie.valor end) as motivo_cancelamento,
+        max(case when ie.titulo_formulario = 'Tô de Boa - Justificativa de Falta'
+                 and ie.label = 'Justificativa' then ie.valor end) as justificativa_falta
+    from {{ extrair_campos_html_evolucao(
+        source_relation = ref('fct_evolucoes'),
+        id_cols = ['id_evolucao_sk', 'id_atividade', 'id_usuario_sk'],
+        col_html = 'descricao_evolucao'
+    ) }} ie
+    where ie.titulo_formulario like 'Tô de Boa -%'
+    group by ie.id_evolucao_sk
 )
+
 select
     p.id_presenca,
     p.id_usuario,
@@ -54,10 +85,18 @@ select
       then substr(lpad(p.hora_presenca, 4, '0'), 1, 2) || ':' || substr(lpad(p.hora_presenca, 4, '0'), 3, 2)
       else p.hora_presenca
     end as hora_presenca,
-    fe.email as email_unidade
+    fe.email as email_unidade,
+    case when tdi.motivo_desligamento is not null then 'Sim' else 'Não' end as flag_desligamento,
+    tdi.motivo_desligamento,
+    case when tdi.motivo_cancelamento is not null then 'Sim' else 'Não' end as flag_cancelamento_atividades,
+    tdi.motivo_cancelamento,
+    case when tdi.justificativa_falta is not null then 'Sim' else 'Não' end as flag_justificativa_falta,
+    tdi.justificativa_falta
 from presencas p
 left join usuarios u on p.id_usuario = u.id_usuario
 left join atividades a on p.id_atividade = a.id_atividade
 left join filtro_email fe on a.nome_unidade = upper(fe.unidade_atendimento)
 left join membros_atuais ma on p.id_usuario = ma.id_paciente
 left join familia_responsavel mr on ma.id_familia = mr.id_familia
+left join evolucoes e on p.id_usuario = e.id_usuario and p.id_atividade = e.id_atividade
+left join to_de_boa_indicadores tdi on e.id_evolucao_sk = tdi.id_evolucao_sk

--- a/queries/models/marts/atividades/mart_presenca_usuarios.yml
+++ b/queries/models/marts/atividades/mart_presenca_usuarios.yml
@@ -66,3 +66,26 @@ models:
       - name: hora_presenca
         description: "Hora da presença."
         data_type: string
+      - name: flag_desligamento
+        description: "Indica se houve evolução de desligamento no Tô de Boa (Sim/Não)."
+        data_type: string
+
+      - name: motivo_desligamento
+        description: "Motivo do desligamento registrado em evolução Tô de Boa - Desligamento."
+        data_type: string
+
+      - name: flag_cancelamento_atividades
+        description: "Indica se houve evolução de cancelamento no Tô de Boa (Sim/Não)."
+        data_type: string
+
+      - name: motivo_cancelamento
+        description: "Motivo do cancelamento registrado em evolução Tô de Boa - Cancelamento das atividades."
+        data_type: string
+
+      - name: flag_justificativa_falta
+        description: "Indica se houve evolução de justificativa de falta no Tô de Boa (Sim/Não)."
+        data_type: string
+
+      - name: justificativa_falta
+        description: "Justificativa registrada em evolução Tô de Boa - Justificativa de Falta."
+        data_type: string


### PR DESCRIPTION
## Summary

Cria a macro extrair_campos_html_evolucao para parse generico de HTML de evolucoes e enriquece a mart_presenca_usuarios com 3 indicadores do To de Boa.

## What changed

- Macro extrair_campos_html_evolucao (v2): parse por escopo de bloco <p>, split por : <b>, extrai label/valor/titulo/observacoes de forma generica e reutilizavel
- mart_presenca_usuarios: +6 colunas: flag_desligamento, motivo_desligamento, flag_cancelamento_atividades, motivo_cancelamento, flag_justificativa_falta, justificativa_falta
- mart_presenca_usuarios.yml: colunas documentadas

## Testes (validados com dados reais)

- 80 registros To de Boa analisados - 100% de acerto nos 3 indicadores
- 5.508 presencas conectadas a evolucoes via id_atividade
- Macro validada pelo arquiteto

## Deploy

Requires dbt run --full-refresh --select mart_presenca_usuarios