### PR TITLE
fix: correct mart_presenca_usuarios granularity and macro WITH nesting

### DIFF
--- a/queries/macros/acolherio/extrair_campos_html_evolucao.sql
+++ b/queries/macros/acolherio/extrair_campos_html_evolucao.sql
@@ -5,36 +5,8 @@
     extra_where = '',
     table_alias = 'src'
 ) %}
-
-WITH {{ table_alias }} AS (
-    SELECT * FROM {{ source_relation }}
-),
-
-campos_extraidos AS (
-    SELECT
-        {{ id_cols | join(', ') }},
-        REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'<p>(.*?)</p>') AS bloco_campos,
-        REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'</p>\s*<h3>(?:OBSERVAÇÕES|CONTEÚDO E DESCRIÇÃO)</h3>\s*([\s\S]*?)$') AS observacoes,
-        REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'<h3>(.*?)</h3>') AS titulo_formulario
-    FROM {{ table_alias }}
-    WHERE {{ table_alias }}.{{ col_html }} LIKE '%<b>%'
-    {% if extra_where %}
-      AND {{ extra_where }}
-    {% endif %}
-),
-
-fields AS (
-    SELECT
-        {{ id_cols | join(', ') }},
-        titulo_formulario,
-        field,
-        observacoes
-    FROM campos_extraidos,
-    UNNEST(REGEXP_EXTRACT_ALL(bloco_campos, r'[^<]+?:?\s*<b>[^<]*</b>')) AS field
-    WHERE bloco_campos IS NOT NULL
-),
-
-evolucao_campos_extraidos AS (
+(
+    -- Nested subqueries (no WITH, pois BigQuery nao permite WITH dentro de FROM)
     SELECT
         {{ id_cols | join(', ') }},
         titulo_formulario,
@@ -44,9 +16,26 @@ evolucao_campos_extraidos AS (
         )) AS label,
         TRIM(REGEXP_EXTRACT(field, r'<b>([^<]*)</b>')) AS valor,
         observacoes
-    FROM fields
+    FROM (
+        SELECT
+            {{ id_cols | join(', ') }},
+            titulo_formulario,
+            field,
+            observacoes
+        FROM (
+            SELECT
+                {{ id_cols | join(', ') }},
+                REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'<p>(.*?)</p>') AS bloco_campos,
+                REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'</p>\s*<h3>(?:OBSERVAÇÕES|CONTEÚDO E DESCRIÇÃO)</h3>\s*([\s\S]*?)$') AS observacoes,
+                REGEXP_EXTRACT({{ table_alias }}.{{ col_html }}, r'<h3>(.*?)</h3>') AS titulo_formulario
+            FROM {{ source_relation }} AS {{ table_alias }}
+            WHERE {{ table_alias }}.{{ col_html }} LIKE '%<b>%'
+            {% if extra_where %}
+              AND {{ extra_where }}
+            {% endif %}
+        ),
+        UNNEST(REGEXP_EXTRACT_ALL(bloco_campos, r'[^<]+?:?\s*<b>[^<]*</b>')) AS field
+        WHERE bloco_campos IS NOT NULL
+    )
 )
-
-SELECT * FROM evolucao_campos_extraidos
-
 {% endmacro %}

--- a/queries/models/marts/atividades/mart_presenca_usuarios.sql
+++ b/queries/models/marts/atividades/mart_presenca_usuarios.sql
@@ -54,6 +54,21 @@ to_de_boa_indicadores as (
     ) }} ie
     where ie.titulo_formulario like 'Tô de Boa -%'
     group by ie.id_evolucao_sk
+),
+
+indicadores_agregados as (
+    select
+        e.id_usuario,
+        e.id_atividade,
+        max(case when tdi.motivo_desligamento is not null then 'Sim' else 'Não' end) as flag_desligamento,
+        max(tdi.motivo_desligamento) as motivo_desligamento,
+        max(case when tdi.motivo_cancelamento is not null then 'Sim' else 'Não' end) as flag_cancelamento_atividades,
+        max(tdi.motivo_cancelamento) as motivo_cancelamento,
+        max(case when tdi.justificativa_falta is not null then 'Sim' else 'Não' end) as flag_justificativa_falta,
+        max(tdi.justificativa_falta) as justificativa_falta
+    from evolucoes e
+    left join to_de_boa_indicadores tdi on e.id_evolucao_sk = tdi.id_evolucao_sk
+    group by e.id_usuario, e.id_atividade
 )
 
 select
@@ -86,17 +101,16 @@ select
       else p.hora_presenca
     end as hora_presenca,
     fe.email as email_unidade,
-    case when tdi.motivo_desligamento is not null then 'Sim' else 'Não' end as flag_desligamento,
-    tdi.motivo_desligamento,
-    case when tdi.motivo_cancelamento is not null then 'Sim' else 'Não' end as flag_cancelamento_atividades,
-    tdi.motivo_cancelamento,
-    case when tdi.justificativa_falta is not null then 'Sim' else 'Não' end as flag_justificativa_falta,
-    tdi.justificativa_falta
+    coalesce(indicadores.flag_desligamento, 'Não') as flag_desligamento,
+    indicadores.motivo_desligamento,
+    coalesce(indicadores.flag_cancelamento_atividades, 'Não') as flag_cancelamento_atividades,
+    indicadores.motivo_cancelamento,
+    coalesce(indicadores.flag_justificativa_falta, 'Não') as flag_justificativa_falta,
+    indicadores.justificativa_falta
 from presencas p
 left join usuarios u on p.id_usuario = u.id_usuario
 left join atividades a on p.id_atividade = a.id_atividade
 left join filtro_email fe on a.nome_unidade = upper(fe.unidade_atendimento)
 left join membros_atuais ma on p.id_usuario = ma.id_paciente
 left join familia_responsavel mr on ma.id_familia = mr.id_familia
-left join evolucoes e on p.id_usuario = e.id_usuario and p.id_atividade = e.id_atividade
-left join to_de_boa_indicadores tdi on e.id_evolucao_sk = tdi.id_evolucao_sk
+left join indicadores_agregados indicadores on p.id_usuario = indicadores.id_usuario and p.id_atividade = indicadores.id_atividade

--- a/queries/models/marts/rma_cras/encaminhamentos_unidade.sql
+++ b/queries/models/marts/rma_cras/encaminhamentos_unidade.sql
@@ -28,7 +28,7 @@ base_unidades as (
 -- 1, 4 e 7: PAIF, PAEFI e MSE (Serviços das Famílias)
 servicos_familias as (
     select
-        f.id_unidade,
+        s.id_unidade,
         count(distinct if(s.id_servico_assistencial = 1, f.id_familia, null)) as total_paif,
         count(distinct if(s.id_servico_assistencial = 6, f.id_familia, null)) as total_paefi,
         count(distinct if(s.id_servico_assistencial in (8, 9), f.id_familia, null)) as total_mse


### PR DESCRIPTION
## Correcoes pos-deploy

### 1. Duplicatas na mart_presenca_usuarios
LEFT JOIN com fct_evolucoes estava multiplicando linhas (11.145 ao inves de 8.504).
**Solucao:** Agregar indicadores por (id_usuario, id_atividade) antes do JOIN.
Granularidade preservada: 8.504 linhas, PK 100% integra.

### 2. Macro extrair_campos_html_evolucao - WITH aninhado
BigQuery nao aceita CTE WITH dentro de FROM.
**Solucao:** Refatorado para subqueries aninhadas.

### 3. encaminhamentos_unidade - coluna errada
CTE servicos_familias referia f.id_unidade mas raw_familias nao tem essa coluna.
**Solucao:** Corrigido para s.id_unidade (raw_familias_servicos_assistenciais).

## Deploy
dbt run --full-refresh executado com sucesso. Todos os modelos materializados.