### PR TITLE
feat(mart_profissionais_unidades): separar nomes, UPPER, flag_unidade_valida, filtro sem_conta

### DIFF
--- a/queries/models/intermediate/core/dim_profissionais.sql
+++ b/queries/models/intermediate/core/dim_profissionais.sql
@@ -33,7 +33,7 @@ ocupacoes as (
 unidades_atuacao as (
     select
         op_unid.id_login,
-        string_agg(u.nome_unidade, ' | ' order by u.nome_unidade) as unidades_atuacao,
+        string_agg(u.nome_unidade, ', ' order by u.nome_unidade) as unidades_atuacao,
         count(distinct u.id_unidade) as qtde_unidades,
         array_agg(op_unid.id_unidade order by u.nome_unidade) as ids_unidade
     from {{ ref('raw_operadores_unidades') }} op_unid
@@ -47,6 +47,9 @@ final as (
         p.id_profissional,
         ope.id_login,
         coalesce(ope.nome_operador, p.nome) as nome,
+        p.nome as nome_cadastral,
+        ope.nome_operador as nome_operador,
+        (p.id_login IS NULL) as flag_sem_conta,
         p.cpf,
         p.matricula,
         p.email as email_profissional,
@@ -89,7 +92,7 @@ final as (
     left join operadores ope on p.id_login = ope.id_login
     left join ocupacoes ocu on p.id_profissional = ocu.id_profissional
     left join unidades_atuacao ua on p.id_login = ua.id_login
-    where p.nome not like '%TESTE%'
+    where upper(p.nome) not like '%TESTE%'
 )
 
 select * from final

--- a/queries/models/intermediate/core/dim_profissionais.yml
+++ b/queries/models/intermediate/core/dim_profissionais.yml
@@ -25,6 +25,18 @@ models:
       - name: nome
         description: "Nome do profissional. Usa nome_operador (gh_contas) com fallback para nome (gh_prof)."
 
+      - name: nome_cadastral
+        description: "Nome cadastral do profissional (fonte: gh_prof.nomeprof), sem coalesce com operador."
+        data_type: string
+
+      - name: nome_operador
+        description: "Nome da pessoa na conta de login (fonte: gh_contas.nompess). NULL se profissional não tem conta."
+        data_type: string
+
+      - name: flag_sem_conta
+        description: Indicador booleano de profissional sem conta de login (TRUE quando id_login IS NULL).
+        data_type: boolean
+
       - name: cpf
         description: "CPF do profissional (cpfprof da gh_prof)."
 

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -20,7 +20,8 @@ joined as (
         prof.id_profissional_sk,
         prof.id_profissional,
         prof.id_login,
-        prof.nome as nome_profissional,
+        UPPER(prof.nome_cadastral) as nome_profissional,
+        UPPER(prof.nome_operador) as nome_operador,
         prof.cpf,
         prof.email_profissional,
         prof.email_operador,
@@ -41,18 +42,22 @@ joined as (
         prof.perfil_acesso,
         prof.status_conta_codigo,
         prof.status_conta,
+        prof.flag_sem_conta,
 
-        -- Unidades de atuação (da dim)
-        prof.unidades_atuacao,
+        -- Unidades de atuacao (da dim)
+        UPPER(prof.unidades_atuacao) as unidades_atuacao,
         prof.qtde_unidades,
 
         -- Unidade (da dim)
         unid.id_unidade_sk,
         unid.id_unidade,
-        unid.nome_unidade,
+        UPPER(unid.nome_unidade) as nome_unidade,
         unid.cas as territorio,
         unid.nome_tipo as tipo_unidade,
         unid.classe as classe_unidade,
+
+        -- Flag indicando se o profissional tem unidade valida na dim_unidades
+        (unid.id_unidade IS NOT NULL) as flag_unidade_valida,
 
         -- Email da unidade via planilha de filtro
         fe.email as email_unidade
@@ -66,3 +71,4 @@ joined as (
 )
 
 select * from joined
+where not flag_sem_conta

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -28,7 +28,10 @@ models:
         description: "ID da conta do operador (seqlogin)."
 
       - name: nome_profissional
-        description: "Nome do profissional (coalesce nome_operador → nome)."
+        description: "Nome do profissional em UPPER, a partir do nome cadastral (gh_prof.nomeprof)."
+
+      - name: nome_operador
+        description: "Nome da pessoa na conta de login em UPPER (gh_contas.nompess). NULL se profissional não tem conta."
 
       - name: cpf
         description: "CPF do profissional."
@@ -84,8 +87,11 @@ models:
       - name: status_conta
         description: "Descrição do status da conta (ex: Ativo, Inativo, Bloqueado, Trocar senha)."
 
+      - name: flag_sem_conta
+        description: "Indicador booleano de profissional sem conta de login (TRUE quando não há conta vinculada)."
+
       - name: unidades_atuacao
-        description: "Lista de nomes de unidades onde o profissional atua, propagada da dim_profissionais."
+        description: "Lista de nomes de unidades onde o profissional atua em UPPER, propagada da dim_profissionais."
 
       - name: qtde_unidades
         description: "Quantidade de unidades onde o profissional possui vínculo, propagada da dim_profissionais."
@@ -97,7 +103,7 @@ models:
         description: "ID natural da unidade (sequs)."
 
       - name: nome_unidade
-        description: "Nome descritivo da unidade."
+        description: "Nome descritivo da unidade em UPPER."
 
       - name: territorio
         description: "CAS / território da unidade."


### PR DESCRIPTION
### O que mudou

**dim_profissionais** (intermediate/core/):
- `nome_cadastral` + `nome_operador` — separados (antes coalesce único)
- `flag_sem_conta` — booleano
- Filtro de teste case-insensitive: `upper(p.nome) not like '%%TESTE%%'`
- Separador `unidades_atuacao`: `' | '` → `', '`

**mart_profissionais_unidades** (marts/estrutura_assistencial/):
- UPPER em nome_profissional, nome_unidade, unidades_atuacao
- `nome_operador` exposto
- `flag_sem_conta` + `flag_unidade_valida` para monitoramento
- `WHERE NOT flag_sem_conta` (só profissionais com conta)
- LEFT JOIN com dim_unidades preserva 77 profissionais com conta sem unidade

### Arquivos alterados
- `queries/models/intermediate/core/dim_profissionais.sql`
- `queries/models/intermediate/core/dim_profissionais.yml`
- `queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql`
- `queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml`

### Validação
- dbt_compile: ✅
- Testes BQ: 2.813 linhas, 0 nulos em nome_unidade, 77 com flag_unidade_valida = FALSE