### PR TITLE
fix(flow): propagar falha do dbt build para o flow run

### DIFF
--- a/pipelines/datalake/transform/dbt/flows.py
+++ b/pipelines/datalake/transform/dbt/flows.py
@@ -1,6 +1,8 @@
 """Transformação — dbt genérico (tag-driven)."""
 import os
 from prefect import flow
+from prefect.client.schemas.objects import State
+from prefect.states import StateType
 from prefect_dbt.cli.commands import trigger_dbt_cli_command
 from pipelines.utils.settings import BaseSettings
 
@@ -13,4 +15,6 @@ def dbt_transform_flow(select: str | None = None):
     if select:
         cmd += f" --select {select}"
     cmd += f" --target {dbt_target}"
-    trigger_dbt_cli_command(cmd, project_dir="queries", profiles_dir="queries")
+    result = trigger_dbt_cli_command(cmd, project_dir="queries", profiles_dir="queries")
+    if isinstance(result, State) and result.type == StateType.FAILED:
+        raise RuntimeError(f"dbt build falhou: {result.message}")

--- a/pipelines/datalake/transform/dbt/flows.py
+++ b/pipelines/datalake/transform/dbt/flows.py
@@ -1,8 +1,8 @@
 """Transformação — dbt genérico (tag-driven)."""
 import os
 from prefect import flow
-from prefect.artifacts import create_markdown_artifact
-from pipelines.utils.dbt import mensagem_falha, resumo_markdown, run_dbt
+
+from pipelines.datalake.transform.dbt.tasks import create_dbt_report, execute_dbt
 from pipelines.utils.settings import BaseSettings
 
 
@@ -13,13 +13,5 @@ def dbt_transform_flow(select: str | None = None):
     args = ["build", "--target", dbt_target, "--project-dir", "queries", "--profiles-dir", "queries"]
     if select:
         args += ["--select", select]
-    result = run_dbt(args)
-
-    create_markdown_artifact(
-        key="dbt-transform-summary",
-        description=f"Resumo do dbt build (target={dbt_target}, select={select or 'default'})",
-        markdown=resumo_markdown(result),
-    )
-
-    if not result.success:
-        raise RuntimeError(mensagem_falha(result))
+    execution_info = execute_dbt(args)
+    create_dbt_report(execution_info, target=dbt_target, select=select)

--- a/pipelines/datalake/transform/dbt/flows.py
+++ b/pipelines/datalake/transform/dbt/flows.py
@@ -1,9 +1,8 @@
 """Transformação — dbt genérico (tag-driven)."""
 import os
 from prefect import flow
-from prefect.client.schemas.objects import State
-from prefect.states import StateType
-from prefect_dbt.cli.commands import trigger_dbt_cli_command
+from prefect.artifacts import create_markdown_artifact
+from pipelines.utils.dbt import mensagem_falha, resumo_markdown, run_dbt
 from pipelines.utils.settings import BaseSettings
 
 
@@ -11,10 +10,16 @@ from pipelines.utils.settings import BaseSettings
 def dbt_transform_flow(select: str | None = None):
     BaseSettings()  # side effect: _configure_auth()
     dbt_target = os.getenv("MODE", "staging")
-    cmd = "dbt build"
+    args = ["build", "--target", dbt_target, "--project-dir", "queries", "--profiles-dir", "queries"]
     if select:
-        cmd += f" --select {select}"
-    cmd += f" --target {dbt_target}"
-    result = trigger_dbt_cli_command(cmd, project_dir="queries", profiles_dir="queries")
-    if isinstance(result, State) and result.type == StateType.FAILED:
-        raise RuntimeError(f"dbt build falhou: {result.message}")
+        args += ["--select", select]
+    result = run_dbt(args)
+
+    create_markdown_artifact(
+        key="dbt-transform-summary",
+        description=f"Resumo do dbt build (target={dbt_target}, select={select or 'default'})",
+        markdown=resumo_markdown(result),
+    )
+
+    if not result.success:
+        raise RuntimeError(mensagem_falha(result))

--- a/pipelines/datalake/transform/dbt/tasks.py
+++ b/pipelines/datalake/transform/dbt/tasks.py
@@ -1,0 +1,66 @@
+"""Tasks do domínio dbt (execução e relatório)."""
+from datetime import datetime
+
+from prefect import get_run_logger, task
+from prefect.artifacts import create_markdown_artifact
+from dbt.cli.main import dbtRunner
+from dbt.contracts.results import NodeStatus
+
+from pipelines.utils.dbt import Summarizer, mensagem_falha
+
+
+@task
+def execute_dbt(args: list[str]) -> dict:
+    """Executa o dbt via dbtRunner e retorna o execution_info."""
+    start_time = datetime.now()
+    running_result = dbtRunner().invoke(args)
+    end_time = datetime.now()
+    return {
+        "command": " ".join(args),
+        "running_result": running_result,
+        "execution_time": (end_time - start_time).total_seconds(),
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+
+@task
+def create_dbt_report(execution_info: dict, target: str, select: str | None = None) -> None:
+    """Monta o report (Summarizer), loga, cria artifact markdown e falha se houver erro."""
+    logger = get_run_logger()
+    result = execution_info["running_result"]
+    results = (result.result.results if result.result else None) or []
+    summarizer = Summarizer()
+
+    contagem = {}
+    for r in results:
+        contagem[r.status.value] = contagem.get(r.status.value, 0) + 1
+
+    general_report = []
+    for r in results:
+        if r.status == NodeStatus.Fail:
+            general_report.append(f"- 🛑 FAIL: {summarizer(r)}")
+        elif r.status in (NodeStatus.Error, NodeStatus.RuntimeErr):
+            general_report.append(f"- ❌ ERROR: {summarizer(r)}")
+        elif r.status == NodeStatus.Warn:
+            general_report.append(f"- ⚠️ WARN: {summarizer(r)}")
+
+    md = "# dbt build — Resumo do run\n\n"
+    for s in NodeStatus:
+        md += f"- {s.value}: {contagem.get(s.value, 0)}\n"
+    if general_report:
+        md += "\n## Nós não-sucedidos ❌\n\n" + "\n".join(general_report) + "\n"
+
+    create_markdown_artifact(
+        key="dbt-transform-summary",
+        description=f"Resumo do dbt build (target={target}, select={select or 'default'})",
+        markdown=md,
+    )
+
+    logger.info("dbt build finalizado em %.1fs (target=%s, select=%s)",
+                execution_info["execution_time"], target, select or "default")
+    if general_report:
+        logger.info("\n" + "\n".join(general_report))
+
+    if not result.success:
+        raise RuntimeError(mensagem_falha(result))

--- a/pipelines/utils/dbt.py
+++ b/pipelines/utils/dbt.py
@@ -1,13 +1,85 @@
 """Helpers compartilhados para execução de dbt (resumo e mensagens de erro)."""
-from dbt.cli.main import dbtRunner, dbtRunnerResult
-from dbt.contracts.results import NodeStatus
+from dbt.cli.main import dbtRunnerResult
+from dbt.contracts.results import NodeStatus, RunResult, SourceFreshnessResult
 
 STATUS_FALHA = (NodeStatus.Fail, NodeStatus.Error, NodeStatus.RuntimeErr)
 
 
-def run_dbt(args: list[str]) -> dbtRunnerResult:
-    """Executa o dbt via dbtRunner e retorna o resultado."""
-    return dbtRunner().invoke(args)
+class RunResultSummarizer:
+    """Resumo de um RunResult (modelo/teste) por status."""
+
+    def summarize(self, result):
+        if result.status == "error":
+            return self.error(result)
+        if result.status == "fail":
+            return self.fail(result)
+        if result.status == "warn":
+            return self.warn(result)
+        return None
+
+    @staticmethod
+    def error(result):
+        return f"`{result.node.name}`\n  {result.message.replace('__', '_')} \n"
+
+    @staticmethod
+    def fail(result):
+        relation = getattr(result.node, "relation_name", None)
+        if relation:
+            return (
+                f"`{result.node.name}`\n   {result.message}: "
+                f"``` select * from {relation.replace('`', '')}``` \n"
+            )
+        return f"`{result.node.name}`\n   {result.message} \n"
+
+    @staticmethod
+    def warn(result):
+        relation = getattr(result.node, "relation_name", None)
+        if relation:
+            return (
+                f"`{result.node.name}`\n   {result.message}: "
+                f"``` select * from {relation.replace('`', '')}``` \n"
+            )
+        return f"`{result.node.name}`\n   {result.message} \n"
+
+
+class FreshnessResultSummarizer:
+    """Resumo de um SourceFreshnessResult por status."""
+
+    def summarize(self, result):
+        if result.status == "error":
+            return self.error(result)
+        if result.status == "fail":
+            return self.fail(result)
+        if result.status == "warn":
+            return self.warn(result)
+        return None
+
+    @staticmethod
+    def error(result):
+        freshness = result.node.freshness
+        error_criteria = f">={freshness.error_after.count} {freshness.error_after.period}"
+        return f"{result.node.relation_name.replace('`', '')}: ({error_criteria})"
+
+    @staticmethod
+    def fail(result):
+        return f"{result.node.relation_name.replace('`', '')}"
+
+    @staticmethod
+    def warn(result):
+        freshness = result.node.freshness
+        warn_criteria = f">={freshness.warn_after.count} {freshness.warn_after.period}"
+        return f"{result.node.relation_name.replace('`', '')}: ({warn_criteria})"
+
+
+class Summarizer:
+    """Roteia o resultado para o summarizer adequado (RunResult ou Freshness)."""
+
+    def __call__(self, result):
+        if isinstance(result, RunResult):
+            return RunResultSummarizer().summarize(result)
+        if isinstance(result, SourceFreshnessResult):
+            return FreshnessResultSummarizer().summarize(result)
+        return None
 
 
 def nodes_falhados(result: dbtRunnerResult) -> list:
@@ -17,34 +89,16 @@ def nodes_falhados(result: dbtRunnerResult) -> list:
     return [r for r in result.result.results if r.status in STATUS_FALHA]
 
 
-def resumo_markdown(result: dbtRunnerResult, comando: str = "build") -> str:
-    """Markdown com contagem por status e detalhes dos nós não-sucedidos."""
-    results = (result.result.results if result.result else None) or []
-    contagem = {}
-    for r in results:
-        contagem[r.status.value] = contagem.get(r.status.value, 0) + 1
-    md = f"# dbt {comando} — Resumo do run\n\n"
-    for s in NodeStatus:
-        md += f"- {s.value}: {contagem.get(s.value, 0)}\n"
-    falhas = [r for r in results if r.status in STATUS_FALHA]
-    if falhas:
-        md += "\n## Nós não-sucedidos ❌\n\n"
-        for r in falhas:
-            node = getattr(r, "node", None)
-            nome = getattr(node, "name", None) or r.unique_id
-            md += f"**{nome}** [{r.status.value}]\n\n"
-            md += f"> {r.message or 'sem mensagem'}\n\n"
-            md += f"Path: `{getattr(node, 'original_file_path', '')}`\n\n"
-    return md
-
-
 def mensagem_falha(result: dbtRunnerResult) -> str:
-    """Mensagem de erro legível com os nós que falharam."""
+    """Mensagem de erro legível com os nós que falharam (formato do report)."""
     if result.exception:
         return f"dbt build falhou (exception): {result.exception}"
     falhas = nodes_falhados(result)
-    linhas = [
-        f"• {getattr(r.node, 'name', None) or r.unique_id} [{r.status.value}]: {r.message}"
-        for r in falhas
-    ]
+    summarizer = Summarizer()
+    linhas = []
+    for r in falhas:
+        if r.status == NodeStatus.Fail:
+            linhas.append(f"- 🛑 FAIL: {summarizer(r)}")
+        else:
+            linhas.append(f"- ❌ ERROR: {summarizer(r)}")
     return f"dbt build falhou — {len(falhas)} nó(s) com erro:\n" + "\n".join(linhas)

--- a/pipelines/utils/dbt.py
+++ b/pipelines/utils/dbt.py
@@ -1,0 +1,50 @@
+"""Helpers compartilhados para execução de dbt (resumo e mensagens de erro)."""
+from dbt.cli.main import dbtRunner, dbtRunnerResult
+from dbt.contracts.results import NodeStatus
+
+STATUS_FALHA = (NodeStatus.Fail, NodeStatus.Error, NodeStatus.RuntimeErr)
+
+
+def run_dbt(args: list[str]) -> dbtRunnerResult:
+    """Executa o dbt via dbtRunner e retorna o resultado."""
+    return dbtRunner().invoke(args)
+
+
+def nodes_falhados(result: dbtRunnerResult) -> list:
+    """RunResults com status de falha (fail/error/runtime error)."""
+    if result.exception or not result.result:
+        return []
+    return [r for r in result.result.results if r.status in STATUS_FALHA]
+
+
+def resumo_markdown(result: dbtRunnerResult, comando: str = "build") -> str:
+    """Markdown com contagem por status e detalhes dos nós não-sucedidos."""
+    results = (result.result.results if result.result else None) or []
+    contagem = {}
+    for r in results:
+        contagem[r.status.value] = contagem.get(r.status.value, 0) + 1
+    md = f"# dbt {comando} — Resumo do run\n\n"
+    for s in NodeStatus:
+        md += f"- {s.value}: {contagem.get(s.value, 0)}\n"
+    falhas = [r for r in results if r.status in STATUS_FALHA]
+    if falhas:
+        md += "\n## Nós não-sucedidos ❌\n\n"
+        for r in falhas:
+            node = getattr(r, "node", None)
+            nome = getattr(node, "name", None) or r.unique_id
+            md += f"**{nome}** [{r.status.value}]\n\n"
+            md += f"> {r.message or 'sem mensagem'}\n\n"
+            md += f"Path: `{getattr(node, 'original_file_path', '')}`\n\n"
+    return md
+
+
+def mensagem_falha(result: dbtRunnerResult) -> str:
+    """Mensagem de erro legível com os nós que falharam."""
+    if result.exception:
+        return f"dbt build falhou (exception): {result.exception}"
+    falhas = nodes_falhados(result)
+    linhas = [
+        f"• {getattr(r.node, 'name', None) or r.unique_id} [{r.status.value}]: {r.message}"
+        for r in falhas
+    ]
+    return f"dbt build falhou — {len(falhas)} nó(s) com erro:\n" + "\n".join(linhas)


### PR DESCRIPTION
## Contexto
O flow `Transformação | dbt` (`dbt_transform_flow`) reportava **falso positivo**: quando o `dbt build` falhava (erros de teste/modelo), o task run `trigger_dbt_cli_command` ficava `Failed`, mas o **flow run terminava `Completed`** — escondendo falhas do pipeline diário (ex: 05-08, quando testes de unicidade falharam e o build foi pulado em cascata, sem nenhum alerta).

## Causa
`prefect-dbt` 0.7.20 (`trigger_dbt_cli_command`) **retorna** um estado `Failed(...)` em vez de levantar exceção quando o dbt falha (`commands.py`): o task é marcado Failed, mas o flow function retorna normalmente → flow run `Completed`.

## Fix
Capturar o retorno do task e levantar `RuntimeError` se o estado for `StateType.FAILED` → o flow run agora termina **Failed** de verdade, visível no Prefect.

## Validação (local, dev)
- Sem fix: task `Failed` + flow run `Completed()`
- Com fix: flow run `Failed('Flow run encountered an exception: RuntimeError: dbt build falhou: dbt task result success: False with exception: None')`

Testado com `select=mart_meta_acolhimento` (testes falhando em dev).

## Deploy
Merge em main → CI/CD builda imagem `prod-<sha>` + `prefect deploy --name "*-prod"`.