### PR TITLE
fix(core): agregar projetos sociais por usuário (int_usuarios_projetos_sociais)

### DIFF
--- a/queries/models/intermediate/core/dim_usuarios.sql
+++ b/queries/models/intermediate/core/dim_usuarios.sql
@@ -14,11 +14,7 @@ violacoes as (
     select * from {{ ref('int_usuarios_violacoes') }}
 ),
 projetos as (
-    select distinct m.id_paciente, fp.projetos_sociais
-    from {{ ref('raw_membros_familia') }} m
-    left join {{ ref('int_familias_projetos_sociais') }} fp
-        on m.id_familia = fp.id_familia
-    where m.data_saida is null
+    select * from {{ ref('int_usuarios_projetos_sociais') }}
 ),
 final as (
     select
@@ -74,7 +70,7 @@ final as (
     left join saude_mental sm on base.id_paciente = sm.id_paciente
     left join origens ori on sm.codigo_origem = ori.id_origem
     left join violacoes v on base.id_paciente = v.id_usuario
-    left join projetos proj on base.id_paciente = proj.id_paciente
+    left join projetos proj on base.id_paciente = proj.id_usuario
     where base.nome not like '%TESTE%'
 )
 

--- a/queries/models/intermediate/social/int_usuarios_projetos_sociais.sql
+++ b/queries/models/intermediate/social/int_usuarios_projetos_sociais.sql
@@ -1,0 +1,44 @@
+{{ config(materialized="ephemeral") }}
+
+-- Projetos sociais do usuário (via famílias ativas).
+-- Ponte família → usuário: expande os projetos das famílias ativas (data_saida is null)
+-- para os membros, agrega por usuário e deduplica por projeto (mantém o cadastro mais
+-- recente). Garante 1 linha por usuário mesmo com múltiplos vínculos familiares ativos.
+with membros_ativos as (
+    select
+        id_paciente,
+        id_familia
+    from {{ ref('raw_membros_familia') }}
+    where data_saida is null
+),
+
+projetos as (
+    select
+        m.id_paciente as id_usuario,
+        array_concat_agg(fp.projetos_sociais) as projetos_sociais
+    from membros_ativos m
+    left join {{ ref('int_familias_projetos_sociais') }} fp
+        on m.id_familia = fp.id_familia
+    group by m.id_paciente
+),
+
+final as (
+    select
+        id_usuario,
+        array_agg(proj) as projetos_sociais
+    from (
+        select
+            id_usuario,
+            proj,
+            row_number() over (
+                partition by id_usuario, proj.id_projeto_social
+                order by proj.data_cadastro desc nulls last
+            ) as rn
+        from projetos,
+        unnest(projetos_sociais) as proj
+    )
+    where rn = 1
+    group by id_usuario
+)
+
+select * from final


### PR DESCRIPTION
## Contexto
A `dim_usuarios` duplicava usuários com vínculo ativo em 2+ famílias (33 casos reais): o CTE `projetos` joinava `raw_membros_familia` × `int_familias_projetos_sociais` e o `SELECT DISTINCT` não colapsava quando as famílias tinham projetos diferentes (ex: 73286 — família antiga com projeto social, família nova sem) → 2 linhas → `unique_dim_usuarios_id_usuario` FAIL → **cascade SKIP de todo o build diário** (fct_acolhimento_diaria, mart_acolhimento_diaria, mart_meta_acolhimento, mart_presenca_usuarios).

## Solução
O join família→usuário não pertence à dim (acoplamento raw + granularidade errada — as outras ints vêm prontas em granularidade usuário, ex: `int_usuarios_violacoes`).

1. **Nova** `intermediate/social/int_usuarios_projetos_sociais.sql` (ephemeral):
   - Ponte família→usuário (membros ativos × `int_familias_projetos_sociais`)
   - `array_concat_agg` por usuário + dedup por `id_projeto_social` (row_number, mantém cadastro mais recente)
   - Chave `id_usuario` (padrão das ints de usuário)
2. **`dim_usuarios.sql`**: CTE `projetos` vira wrapper da int nova + `left join ... on base.id_paciente = proj.id_usuario` — idêntico ao padrão de `violacoes`.

## Validação (dev)
- Int simulada: 0 duplicatas de projeto por usuário; 73286 → 1 linha `[projeto 2]`
- `dbt run --select dim_usuarios` PASS · `dbt test --select dim_usuarios` **4/4 PASS** (unique inclusos — antes FAIL)
- `dbt run --select fct_acolhimento_diaria` PASS (downstream)
- Dim rebuildada: NATALLI 1 linha

## Impacto
- Desbloqueia o build diário (cascade SKIP morre)
- `int_familias_projetos_sociais` intacta (usada pela `dim_familias`)
- Struct do array inalterado — consumidores não quebram
- Merge com o PR do mart PMA (mesmo arquivo) é limpo — regiões distintas