### PR TITLE
feat(pma): mart de Penas e Medidas Alternativas + nomenclatura de unidade

### DIFF
--- a/queries/models/intermediate/core/dim_usuarios.sql
+++ b/queries/models/intermediate/core/dim_usuarios.sql
@@ -64,7 +64,9 @@ final as (
         -- Enriquecimento com Structs e Flags
         if(v.id_usuario is not null, 'Sim', 'Não') as flag_possui_violacao_direito,
         v.violacoes,
-        proj.projetos_sociais
+        proj.projetos_sociais,
+        base.id_unidade_referencia,
+        base.id_login_cadastro
     from base
     left join detalhes det on base.id_paciente = det.id_paciente
     left join saude_mental sm on base.id_paciente = sm.id_paciente

--- a/queries/models/intermediate/core/dim_usuarios.yml
+++ b/queries/models/intermediate/core/dim_usuarios.yml
@@ -86,3 +86,7 @@ models:
         description: "Indica se possui violação de direito registrada (Sim/Não)."
       - name: violacoes
         description: "Array estruturado de violações de direito (código + descrição)."
+      - name: id_unidade_referencia
+        description: "Unidade de referência do usuário (raw_usuarios.sequsref)."
+      - name: id_login_cadastro
+        description: "ID da conta que cadastrou o usuário (raw_usuarios.id_login_cadastro, seqlogin). FK para dim_profissionais.id_login."

--- a/queries/models/intermediate/core/fct_evolucoes.sql
+++ b/queries/models/intermediate/core/fct_evolucoes.sql
@@ -31,7 +31,8 @@ grupo as (
         null as id_paciente_familia,
         e.id_evolucao_grupo,
         e.id_evolucao,
-        e.id_atividade
+        e.id_atividade,
+        cast(null as datetime) as data_cancelamento
     from {{ ref('raw_evolucoes_grupo') }} e
     left join {{ ref('raw_atividades_grupo') }} a
         on e.id_atividade = a.id_atividade
@@ -60,7 +61,8 @@ uniao as (
         null as id_paciente_familia,
         null as id_evolucao_grupo,
         id_evolucao,
-        null as id_atividade
+        null as id_atividade,
+        cast(data_cancelamento as datetime) as data_cancelamento
     from adm
     union all
     select 
@@ -77,7 +79,8 @@ uniao as (
         id_paciente as id_paciente_familia,
         null as id_evolucao_grupo,
         id_evolucao,
-        null as id_atividade
+        null as id_atividade,
+        cast(data_cancelamento as datetime) as data_cancelamento
     from fam
     union all
     select 
@@ -94,7 +97,8 @@ uniao as (
         null as id_paciente_familia,
         null as id_evolucao_grupo,
         id_evolucao,
-        null as id_atividade
+        null as id_atividade,
+        cast(data_cancelamento as datetime) as data_cancelamento
     from usu
     union all
     select 
@@ -111,7 +115,8 @@ uniao as (
         null as id_paciente_familia,
         id_evolucao_grupo,
         id_evolucao,
-        id_atividade
+        id_atividade,
+        cast(data_cancelamento as datetime) as data_cancelamento
     from grupo
 ),
 
@@ -125,6 +130,7 @@ final as (
         dim_u.id_usuario_sk,
         dim_p.id_profissional_sk,
         dim_un.id_unidade_sk,
+        u.id_unidade,
         u.data_evolucao,
         u.descricao_evolucao,
         u.tipo_evolucao,
@@ -135,7 +141,8 @@ final as (
         u.id_paciente_familia,
         u.id_atividade,
         u.id_evolucao_grupo,
-        u.id_evolucao
+        u.id_evolucao,
+        u.data_cancelamento
     from uniao u
     left join {{ ref('dim_usuarios') }} dim_u on u.id_usuario = dim_u.id_usuario
     left join {{ ref('dim_profissionais') }} dim_p on u.id_profissional = dim_p.id_profissional

--- a/queries/models/intermediate/core/fct_evolucoes.yml
+++ b/queries/models/intermediate/core/fct_evolucoes.yml
@@ -8,3 +8,7 @@ models:
         description: "FK para raw_atividades_grupo (seqatigrp). Origem: módulo grupo."
       - name: id_evolucao_grupo
         description: "FK para raw_evolucoes_grupo (seqevogrp). Origem: módulo grupo."
+      - name: id_unidade
+        description: "Unidade associada à evolução — papel único de unidade da fct (único FK para dim_unidades, espelha as fatos irmãs fct_atendimentos/fct_acolhimento_*). Na origem módulo 'grupo', a unidade vem da ATIVIDADE (raw_atividades_grupo via id_atividade), não é um 'cadastro'; nas origens adm/familia/usuario vem de sequs (unidade do cadastrador). O nome neutro id_unidade evita o viés de 'cadastro', que só se aplica parcialmente."
+      - name: data_cancelamento
+        description: "Data de cancelamento da evolução (dtcancpac/dtcancgrp). NULL para evoluções ativas; evoluções canceladas são excluídas nos marts."

--- a/queries/models/intermediate/social/int_familias_projetos_sociais.sql
+++ b/queries/models/intermediate/social/int_familias_projetos_sociais.sql
@@ -6,6 +6,7 @@ with projetos as (
         id_familia,
         array_agg(struct(
             id_projeto_social,
+            id_unidade,
             indicador_ativo,
             data_cadastro,
             data_cancelamento

--- a/queries/models/marts/risco_social/mart_usuarios_medidas_alternativas.sql
+++ b/queries/models/marts/risco_social/mart_usuarios_medidas_alternativas.sql
@@ -63,6 +63,7 @@ evolucoes_pma as (
     where e.codigo_abrangencia = 18
       and e.data_cancelamento is null
       and e.origem_modulo in ('familia', 'usuario')
+      and coalesce(du.id_usuario, e.id_paciente_familia) is not null
 ),
 
 -- Campos do formulário PMA (última evolução por pessoa)

--- a/queries/models/marts/risco_social/mart_usuarios_medidas_alternativas.sql
+++ b/queries/models/marts/risco_social/mart_usuarios_medidas_alternativas.sql
@@ -1,0 +1,182 @@
+-- Mart: Usuários em Penas e Medidas Alternativas (PMA)
+-- Grão: 1 linha por pessoa (id_paciente). Base do relatório 'PMA por CREAS'.
+--
+-- Origens (array origem_identificacao):
+--   1. indicador_projeto_social: projeto social PMA (id_projeto_social = 23, ativo, sem
+--      cancelamento) no prontuário do usuário (dim_usuarios.projetos_sociais — array já
+--      expandido da família para os membros ativos na própria dimensão).
+--   2. formulario_pma: evolução não cancelada com codigo_abrangencia = 18 e formulário
+--      'CREAS - Penas e Medidas Alternativas' (módulos família e usuário). Campos extraídos
+--      via macro extrair_formulario (última evolução por pessoa, latest_by = data_evolucao).
+--
+-- Vínculo ao CREAS — Cenário A (fallback para vazios, validado com o Leone):
+--   id_unidade_vinculo = COALESCE(unidade_cadastro_marcacao, unidade_referencia,
+--   unidade_cadastro_operador):
+--     marcação: unidade que cadastrou a marcação (última evolução do formulário, senão a do
+--       indicador do projeto 23); referência: id_unidade_referencia (dim_usuarios);
+--       operador: unidade do operador cadastrante (dim_profissionais.ids_unidade[0]).
+--   vinculado_creas = (id_unidade_vinculo é CREAS em dim_unidades, id_tipo_unidade = 13).
+--   Unidades de teste (nome contendo 'TESTE') são excluídas por design da dim_unidades: não são
+--   CREAS nem aparecem em nome_unidade_vinculo. COALESCE puro, sem flags de teste.
+
+{{ config(materialized='table', tags=['risco_social']) }}
+
+with
+
+-- Base: usuários únicos da dimensão (robustez contra duplicidade de linha por usuário)
+usuarios_unicos as (
+    select
+        id_usuario,
+        any_value(id_unidade_referencia) as id_unidade_referencia,
+        any_value(id_login_cadastro) as id_login_cadastro,
+        array_concat_agg(projetos_sociais) as projetos_sociais
+    from {{ ref('dim_usuarios') }}
+    group by id_usuario
+),
+
+-- ORIGEM 1: indicador do projeto social 23 (ativo, sem cancelamento) -> 1 linha por pessoa
+indicador_pma as (
+    select
+        id_usuario as id_paciente,
+        min(p.id_unidade) as id_unidade_cadastro
+    from usuarios_unicos,
+    unnest(projetos_sociais) as p
+    where p.id_projeto_social = 23
+      and p.indicador_ativo = 'S'
+      and p.data_cancelamento is null
+    group by id_usuario
+),
+
+-- ORIGEM 2: evoluções do formulário PMA (família + usuário), não canceladas
+evolucoes_pma as (
+    select
+        coalesce(du.id_usuario, e.id_paciente_familia) as id_paciente,
+        e.id_unidade as id_unidade_cadastro,
+        e.data_evolucao,
+        e.descricao_evolucao,
+        e.codigo_abrangencia,
+        e.origem_modulo,
+        e.id_familia
+    from {{ ref('fct_evolucoes') }} e
+    left join {{ ref('dim_usuarios') }} du
+        on e.id_usuario_sk = du.id_usuario_sk
+    where e.codigo_abrangencia = 18
+      and e.data_cancelamento is null
+      and e.origem_modulo in ('familia', 'usuario')
+),
+
+-- Campos do formulário PMA (última evolução por pessoa)
+formulario_pma as (
+    {{ extrair_formulario(
+        source_relation = 'evolucoes_pma',
+        group_cols = ['id_paciente'],
+        codigo_abrangencia = 18,
+        titulo_formulario = 'CREAS - Penas e Medidas Alternativas',
+        latest_by = 'data_evolucao',
+        campos = [
+            {'label': '%Data em que o usuário se apresentou%', 'col': 'data_apresentacao', 'type': 'date', 'format': '%d/%m/%Y'},
+            {'label': '%Data de início da prestação de serviços%', 'col': 'data_inicio_servico', 'type': 'date', 'format': '%d/%m/%Y'},
+            {'label': '%Local onde está cumprindo a pena%', 'col': 'local_cumprimento_pena'},
+            {'label': '%Data do desligamento%', 'col': 'data_desligamento', 'type': 'date', 'format': '%d/%m/%Y'},
+            {'label': '%Motivo do desligamento%', 'col': 'motivo_desligamento'},
+            {'label': '%Tempo de cumprimento da pena alternativa%', 'col': 'tempo_cumprimento_pena'},
+        ]
+    ) }}
+),
+
+-- Unidade de cadastro, família e data da última evolução PMA por pessoa (max_by)
+ultima_evolucao_pma as (
+    select
+        id_paciente,
+        max(data_evolucao) as data_ultima_evolucao_formulario,
+        max_by(id_unidade_cadastro, data_evolucao) as id_unidade_cadastro,
+        max_by(id_familia, data_evolucao) as id_familia
+    from evolucoes_pma
+    group by id_paciente
+),
+
+-- União das origens com identificação por pessoa
+pessoas_origens as (
+    select
+        id_paciente,
+        array_agg(distinct origem order by origem) as origem_identificacao
+    from (
+        select distinct id_paciente, 'indicador_projeto_social' as origem from indicador_pma
+        union all
+        select distinct id_paciente, 'formulario_pma' as origem from evolucoes_pma
+    )
+    group by id_paciente
+),
+
+-- FALLBACK nível 2: unidade do operador cadastrante (via dim_profissionais)
+referencia_operador as (
+    select
+        uu.id_usuario as id_paciente,
+        uu.id_unidade_referencia,
+        dp.ids_unidade[safe_offset(0)] as id_unidade_cadastro_operador
+    from usuarios_unicos uu
+    left join {{ ref('dim_profissionais') }} dp
+        on uu.id_login_cadastro = dp.id_login
+),
+
+-- Vínculo efetivo (Cenário A): COALESCE(marcação, referência, operador) puro
+pessoa_vinculo as (
+    select
+        po.id_paciente,
+        coalesce(ue.id_unidade_cadastro, i.id_unidade_cadastro) as id_unidade_cadastro_marcacao,
+        ro.id_unidade_referencia,
+        ro.id_unidade_cadastro_operador,
+        case
+            when coalesce(ue.id_unidade_cadastro, i.id_unidade_cadastro) is not null then 'unidade_cadastro_marcacao'
+            when ro.id_unidade_referencia is not null then 'unidade_referencia'
+            when ro.id_unidade_cadastro_operador is not null then 'unidade_cadastro_operador'
+            else 'sem_unidade'
+        end as origem_unidade_vinculo
+    from pessoas_origens po
+    left join ultima_evolucao_pma ue on po.id_paciente = ue.id_paciente
+    left join indicador_pma i on po.id_paciente = i.id_paciente
+    left join referencia_operador ro on po.id_paciente = ro.id_paciente
+),
+
+final as (
+    select
+        pv.id_paciente,
+        ue.id_familia,
+        po.origem_identificacao,
+        (i.id_paciente is not null) as flag_indicador_projeto23,
+        (ue.id_paciente is not null) as flag_formulario_pma,
+        coalesce(
+            pv.id_unidade_cadastro_marcacao,
+            pv.id_unidade_referencia,
+            pv.id_unidade_cadastro_operador
+        ) as id_unidade_vinculo,
+        pv.origem_unidade_vinculo,
+        duv.nome_unidade as nome_unidade_vinculo,
+        (duv.id_tipo_unidade = 13) as vinculado_creas,
+        pv.id_unidade_referencia,
+        dur.nome_unidade as nome_unidade_referencia,
+        pv.id_unidade_cadastro_operador,
+        duo.nome_unidade as nome_unidade_cadastro_operador,
+        fpm.data_apresentacao,
+        fpm.data_inicio_servico,
+        fpm.local_cumprimento_pena,
+        fpm.data_desligamento,
+        fpm.motivo_desligamento,
+        fpm.tempo_cumprimento_pena,
+        ue.data_ultima_evolucao_formulario
+    from pessoa_vinculo pv
+    left join pessoas_origens po on pv.id_paciente = po.id_paciente
+    left join ultima_evolucao_pma ue on pv.id_paciente = ue.id_paciente
+    left join indicador_pma i on pv.id_paciente = i.id_paciente
+    left join {{ ref('dim_unidades') }} duv
+        on coalesce(
+            pv.id_unidade_cadastro_marcacao,
+            pv.id_unidade_referencia,
+            pv.id_unidade_cadastro_operador
+        ) = duv.id_unidade
+    left join {{ ref('dim_unidades') }} dur on pv.id_unidade_referencia = dur.id_unidade
+    left join {{ ref('dim_unidades') }} duo on pv.id_unidade_cadastro_operador = duo.id_unidade
+    left join formulario_pma fpm on pv.id_paciente = fpm.id_paciente
+)
+
+select * from final

--- a/queries/models/marts/risco_social/mart_usuarios_medidas_alternativas.yml
+++ b/queries/models/marts/risco_social/mart_usuarios_medidas_alternativas.yml
@@ -1,0 +1,119 @@
+version: 2
+
+models:
+  - name: mart_usuarios_medidas_alternativas
+    description: >
+      Mart de usuários em Penas e Medidas Alternativas (PMA).
+      Granularidade: 1 linha por pessoa (id_paciente). Base do relatório
+      'Penas e Medidas Alternativas (PMA) por CREAS' (agregação por CREAS).
+
+      Duas origens de identificação (coluna array origem_identificacao):
+      1. indicador_projeto_social: participação em projeto social PMA
+         (id_projeto_social = 23, indicador_ativo = 'S', sem data_cancelamento)
+         no prontuário do usuário (dim_usuarios.projetos_sociais — array já
+         expandido da família para os membros ativos na própria dimensão).
+      2. formulario_pma: evolução não cancelada (data_cancelamento IS NULL) com
+         codigo_abrangencia = 18 e formulário 'CREAS - Penas e Medidas Alternativas'
+         (módulos família e usuário). Campos extraídos via macro extrair_formulario
+         (última evolução por pessoa, latest_by = data_evolucao).
+
+      Vínculo ao CREAS — Cenário A (fallback para vazios, validado com o Leone):
+      id_unidade_vinculo = COALESCE(unidade_cadastro_marcacao, unidade_referencia,
+      unidade_cadastro_operador). vinculado_creas = (id_unidade_vinculo é CREAS,
+      dim_unidades id_tipo_unidade = 13). A unidade EFETIVA do vínculo é que define:
+      cada pessoa tem uma única unidade efetiva (após COALESCE) e é ela que é
+      testada contra o tipo 13.
+
+      Tratamento de unidades de teste (nome contendo 'TESTE'): exclusão por design
+      da dim_unidades (filtro de nome). Unidades de teste não são reconhecidas como
+      CREAS (vinculado_creas = FALSE) nem aparecem em nome_unidade_vinculo.
+      O COALESCE é puro — não há flags nem ifs de teste.
+    columns:
+      - name: id_paciente
+        description: 'Identificador único da pessoa (indivíduo).'
+        tests:
+          - not_null
+          - unique
+
+      - name: id_familia
+        description: >
+          Família da última evolução do formulário PMA da pessoa
+          (fct_evolucoes.id_familia, origem módulo família). Pode ser NULL se a
+          pessoa foi identificada apenas pelo indicador do projeto social 23.
+
+      - name: origem_identificacao
+        description: >
+          Array de strings com as origens que identificaram a pessoa:
+          'indicador_projeto_social' e/ou 'formulario_pma'.
+
+      - name: flag_indicador_projeto23
+        description: 'TRUE se a pessoa participa do projeto social PMA (id_projeto_social = 23) ativo e sem cancelamento.'
+
+      - name: flag_formulario_pma
+        description: 'TRUE se a pessoa possui ao menos uma evolução não cancelada com o formulário PMA (codigo_abrangencia = 18).'
+
+      - name: id_unidade_vinculo
+        description: >
+          Unidade de vínculo efetiva da pessoa (Cenário A):
+          COALESCE(unidade_cadastro_marcacao, unidade_referencia, unidade_cadastro_operador).
+          Pode ser NULL (origem_unidade_vinculo = 'sem_unidade'). Unidades de teste não
+          aparecem (excluídas por design da dim_unidades no join de nome/tipo).
+
+      - name: origem_unidade_vinculo
+        description: >
+          Origem do vínculo efetivo: 'unidade_cadastro_marcacao' (unidade que cadastrou a
+          marcação), 'unidade_referencia' (id_unidade_referencia do usuário — fallback
+          nível 1), 'unidade_cadastro_operador' (unidade do operador cadastrante via
+          dim_profissionais — fallback nível 2) ou 'sem_unidade' (nenhum vínculo).
+
+      - name: nome_unidade_vinculo
+        description: >
+          Nome da unidade de vínculo efetiva (dim_unidades). NULL se sem unidade ou se a
+          unidade é de teste (não existe na dim_unidades).
+
+      - name: vinculado_creas
+        description: >
+          TRUE se a unidade de vínculo efetiva (id_unidade_vinculo) é um CREAS
+          (dim_unidades, id_tipo_unidade = 13). FALSE para pessoas sem unidade, com
+          vínculo em unidade não-CREAS (ex: CRAS) ou em unidade de teste.
+
+      - name: id_unidade_referencia
+        description: >
+          Unidade de referência do usuário (dim_usuarios.id_unidade_referencia, sequsref).
+          Informativo (fallback nível 1 do vínculo).
+
+      - name: nome_unidade_referencia
+        description: 'Nome da unidade de referência do usuário (dim_unidades). NULL se unidade de teste ou inexistente.'
+
+      - name: id_unidade_cadastro_operador
+        description: >
+          Unidade do operador cadastrante do usuário (dim_usuarios.id_operador_cadastro ->
+          dim_profissionais.id_login, ids_unidade[0]). Informativo (fallback nível 2 do vínculo).
+
+      - name: nome_unidade_cadastro_operador
+        description: 'Nome da unidade do operador cadastrante (dim_unidades). NULL se unidade de teste ou inexistente.'
+
+      - name: data_apresentacao
+        description: 'Data em que o usuário se apresentou (campo do formulário PMA, última evolução). Date ou NULL.'
+
+      - name: data_inicio_servico
+        description: 'Data de início da prestação de serviços (campo do formulário PMA, última evolução). Date ou NULL.'
+
+      - name: local_cumprimento_pena
+        description: 'Local onde está cumprindo a pena (campo do formulário PMA, última evolução).'
+
+      - name: data_desligamento
+        description: 'Data do desligamento (campo do formulário PMA, última evolução). Date ou NULL.'
+
+      - name: motivo_desligamento
+        description: >
+          Motivo do desligamento (campo do formulário PMA, última evolução).
+          Ex: 'Término da pena', 'Óbito', 'Infrequência, Não cumprimento da PSC pactuada'.
+
+      - name: tempo_cumprimento_pena
+        description: >
+          Tempo de cumprimento da pena alternativa (campo do formulário PMA, última
+          evolução). Ex: 'Até 1 ano de PSC', 'Entre 3 e 4 anos de PSC'.
+
+      - name: data_ultima_evolucao_formulario
+        description: 'Data da última evolução do formulário PMA registrada para a pessoa.'

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_administrativas.sql
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_administrativas.sql
@@ -7,7 +7,8 @@ with source as (
         seqlogin as id_login,
         dtevopac as data_evolucao,
         dscevopac as descricao_evolucao,
-        indtpevopac as tipo_evolucao
+        indtpevopac as tipo_evolucao,
+        dtcancpac as data_cancelamento
     from {{ source('brutos_acolherio_staging', 'gh_evoluadm') }}
 )
 select * from source

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_familias.sql
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_familias.sql
@@ -8,6 +8,7 @@ with source as (
         dtevopac as data_evolucao,
         dscevopac as descricao_evolucao,
         indtpevopac as tipo_evolucao,
+        dtcancpac as data_cancelamento,
         codabapac as modulo_prontuario,
         seqpac as id_paciente
     from {{ source('brutos_acolherio_staging', 'gh_evolufamil') }}

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_usuarios.sql
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_evolucoes_usuarios.sql
@@ -8,6 +8,7 @@ with source as (
         dtevopac as data_evolucao,
         dscevopac as descricao_evolucao,
         indtpevopac as tipo_evolucao,
+        dtcancpac as data_cancelamento,
         codabapac as codigo_abrangencia
     from {{ source('brutos_acolherio_staging', 'gh_evolupac') }}
 )

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_familias_projetos_sociais.sql
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_familias_projetos_sociais.sql
@@ -3,6 +3,7 @@ with source as (
     select
         seqfamil as id_familia,
         seqprojsoc as id_projeto_social,
+        sequs as id_unidade,
         seqlogincad as id_login_cadastro,
         datcadastr as data_cadastro,
         datcancel as data_cancelamento,

--- a/queries/models/raw/prontuario_carioca_assistencia_social/raw_usuarios.sql
+++ b/queries/models/raw/prontuario_carioca_assistencia_social/raw_usuarios.sql
@@ -2,6 +2,7 @@
 with source as (
     select
         seqpac as id_paciente,
+        sequsref as id_unidade_referencia,
         seqlogin as id_login_cadastro,
         sigufnasc as uf_nascimento,
         dscnomepac as nome,


### PR DESCRIPTION
## Contexto
Assumimos o trabalho em andamento da outra IA (mart PMA) e integramos sobre a main atual (pós-#70/#71/#72), com correções de nomenclatura para alinhar ao padrão do repo.

## Commits (5)

1. **`feat(evolucoes)`**: `data_cancelamento` nas raws adm/fam/usu (`dtcancpac`) + propagação na fct (cast datetime, NULL na origem grupo que já filtra canceladas) + `id_unidade` na select final — integrado sobre a versão da main (#72: id_evolucao + SK novo)
2. **`feat(projetos)`**: `sequs as id_unidade` na raw_familias_projetos_sociais + struct da int — **renomeado de `id_unidade_cadastro`** (padrão das 14 raws)
3. **`feat(usuarios)`**: `sequsref as id_unidade_referencia` + `id_login_cadastro` na dim — **sem o alias `id_operador_cadastro`** (padrão do repo)
4. **`feat(pma)`**: `mart_usuarios_medidas_alternativas` — 2 origens (projeto social 23 + formulário PMA), vínculo CREAS com fallback (marcação → referência → operador); consumidores ajustados aos renames; doc sem referência a query de console inexistente
5. **`fix(pma)`**: descartar evoluções sem paciente resolvido (usuários de teste fora da dim — TESTE NELSON/MARCIA)

## Validação (dev)
- `dbt run --select +mart_usuarios_medidas_alternativas`: **25/25 PASS**
- Testes: fct_evolucoes 2/2 (unique PASS) · dim_usuarios 4/4 · mart PMA 2/2
- Mart: 219 pessoas (186 CREAS via marcação, 10 referência, 9 operador, 13 não-CREAS, 1 sem unidade)
- dim_usuarios sem regressão (73286 → 1 linha, struct com id_unidade)