### PR TITLE
feat(marts): enriquecer mart_profissionais_unidades com metricas e atributos de unidade

### DIFF
--- a/queries/macros/acolherio/mapa_colunas_categoria.sql
+++ b/queries/macros/acolherio/mapa_colunas_categoria.sql
@@ -445,19 +445,18 @@
 {% endmacro %}
 
 
--- Email institucional por território/área programática (AP); cobre CAS 01-10; NULL para GE/sem AP.
-{% macro email_territorio (coluna) %}
+{% macro email_cas (coluna) %}
   case
-    when lower(trim({{ coluna }})) = '10' then 'cas10@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '09' then 'cas9@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '08' then 'cas8@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '07' then 'cas7@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '06' then 'cas6@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '05' then 'cas5@prefeitura.rio'  
-    when lower(trim({{ coluna }})) = '04' then 'cas4@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '03' then 'cas3@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '02' then 'cas2@prefeitura.rio'
-    when lower(trim({{ coluna }})) = '01' then 'cas1@prefeitura.rio'
+    when lower({{ coluna }}) = '10' then 'cas10@prefeitura.rio'
+    when lower({{ coluna }}) = '09' then 'cas9@prefeitura.rio'
+    when lower({{ coluna }}) = '08' then 'cas8@prefeitura.rio'
+    when lower({{ coluna }}) = '07' then 'cas7@prefeitura.rio'
+    when lower({{ coluna }}) = '06' then 'cas6@prefeitura.rio'
+    when lower({{ coluna }}) = '05' then 'cas5@prefeitura.rio'  
+    when lower({{ coluna }}) = '04' then 'cas4@prefeitura.rio'
+    when lower({{ coluna }}) = '03' then 'cas3@prefeitura.rio'
+    when lower({{ coluna }}) = '02' then 'cas2@prefeitura.rio'
+    when lower({{ coluna }}) = '01' then 'cas1@prefeitura.rio'
   end 
 {% endmacro %}
 

--- a/queries/macros/acolherio/mapa_colunas_categoria.sql
+++ b/queries/macros/acolherio/mapa_colunas_categoria.sql
@@ -445,18 +445,19 @@
 {% endmacro %}
 
 
-{% macro email_cas (coluna) %}
+-- Email institucional por território/área programática (AP); cobre CAS 01-10; NULL para GE/sem AP.
+{% macro email_territorio (coluna) %}
   case
-    when lower({{ coluna }}) = '10' then 'cas10@prefeitura.rio'
-    when lower({{ coluna }}) = '09' then 'cas9@prefeitura.rio'
-    when lower({{ coluna }}) = '08' then 'cas8@prefeitura.rio'
-    when lower({{ coluna }}) = '07' then 'cas7@prefeitura.rio'
-    when lower({{ coluna }}) = '06' then 'cas6@prefeitura.rio'
-    when lower({{ coluna }}) = '05' then 'cas5@prefeitura.rio'  
-    when lower({{ coluna }}) = '04' then 'cas4@prefeitura.rio'
-    when lower({{ coluna }}) = '03' then 'cas3@prefeitura.rio'
-    when lower({{ coluna }}) = '02' then 'cas2@prefeitura.rio'
-    when lower({{ coluna }}) = '01' then 'cas1@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '10' then 'cas10@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '09' then 'cas9@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '08' then 'cas8@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '07' then 'cas7@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '06' then 'cas6@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '05' then 'cas5@prefeitura.rio'  
+    when lower(trim({{ coluna }})) = '04' then 'cas4@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '03' then 'cas3@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '02' then 'cas2@prefeitura.rio'
+    when lower(trim({{ coluna }})) = '01' then 'cas1@prefeitura.rio'
   end 
 {% endmacro %}
 

--- a/queries/models/intermediate/core/dim_unidades.sql
+++ b/queries/models/intermediate/core/dim_unidades.sql
@@ -26,8 +26,25 @@ final as (
         b.cas,
         b.esfera,
         b.email_unidade,
-        {{ email_territorio('b.cas') }} as email_territorio,
-        pe.email_planilha,
+        concat(
+            coalesce(
+                case
+                    when lower(trim(b.cas)) = '10' then 'cas10@prefeitura.rio'
+                    when lower(trim(b.cas)) = '09' then 'cas9@prefeitura.rio'
+                    when lower(trim(b.cas)) = '08' then 'cas8@prefeitura.rio'
+                    when lower(trim(b.cas)) = '07' then 'cas7@prefeitura.rio'
+                    when lower(trim(b.cas)) = '06' then 'cas6@prefeitura.rio'
+                    when lower(trim(b.cas)) = '05' then 'cas5@prefeitura.rio'
+                    when lower(trim(b.cas)) = '04' then 'cas4@prefeitura.rio'
+                    when lower(trim(b.cas)) = '03' then 'cas3@prefeitura.rio'
+                    when lower(trim(b.cas)) = '02' then 'cas2@prefeitura.rio'
+                    when lower(trim(b.cas)) = '01' then 'cas1@prefeitura.rio'
+                end,
+                ''
+            ), ',',
+            coalesce(pe.email_planilha, ''), ', ',
+            coalesce(b.email_unidade, '')
+        ) as email_filtro,
         b.flag_unidade_ativa,
         t.id_tipo_unidade,
         t.nome_tipo,

--- a/queries/models/intermediate/core/dim_unidades.sql
+++ b/queries/models/intermediate/core/dim_unidades.sql
@@ -10,6 +10,14 @@ capacidade as (
     select * from {{ ref('int_capacidade_unidades') }}
 ),
 
+planilha_email as (
+    select
+        lower(trim(unidade_atendimento)) as nome_unidade,
+        string_agg(email, ', ') as email_planilha
+    from {{ ref('raw_sheets_filtro_email_prontuario') }}
+    group by 1
+),
+
 final as (
     select
         {{ dbt_utils.generate_surrogate_key(['b.id_unidade']) }} as id_unidade_sk,
@@ -18,6 +26,8 @@ final as (
         b.cas,
         b.esfera,
         b.email_unidade,
+        {{ email_territorio('b.cas') }} as email_territorio,
+        pe.email_planilha,
         b.flag_unidade_ativa,
         t.id_tipo_unidade,
         t.nome_tipo,
@@ -56,6 +66,7 @@ final as (
     from base b
     left join tipo t on b.id_tipo_unidade = t.id_tipo_unidade
     left join capacidade cap on b.id_unidade = cap.id_unidade
+    left join planilha_email pe on lower(trim(b.nome_unidade)) = pe.nome_unidade
     where b.nome_unidade not like '%TESTE%'
 )
 

--- a/queries/models/intermediate/core/dim_unidades.sql
+++ b/queries/models/intermediate/core/dim_unidades.sql
@@ -23,6 +23,20 @@ final as (
         t.nome_tipo,
         t.classe,
         t.descricao_classe,
+        case
+            when t.nome_tipo is null then 'Não Informado'
+            when lower(t.nome_tipo) like 'albergue%' then 'Albergue'
+            when lower(t.nome_tipo) like 'central de recepção%' then 'Central de Recepção'
+            when lower(t.nome_tipo) like '%cras%' then 'CRAS'
+            when lower(t.nome_tipo) like '%creas%' then 'CREAS'
+            when lower(t.nome_tipo) like 'centro de ref.espec.popula%' then 'Centro POP'
+            when lower(t.nome_tipo) like 'complexo da urs%' then 'URS'
+            when lower(t.nome_tipo) like 'urs%' then 'URS'
+            when lower(t.nome_tipo) = 'república' then 'República'
+            when lower(t.nome_tipo) = 'moradia primeiro' then 'Lares Cariocas'
+            when upper(b.nome_unidade) like '%ESCRITÓRIO%' then 'Escritório Social'
+            else t.nome_tipo
+        end as tipo_unidade,
         cap.total_vagas,
         cap.vagas_disponiveis,
         cap.vagas_bloqueadas,

--- a/queries/models/intermediate/core/dim_unidades.yml
+++ b/queries/models/intermediate/core/dim_unidades.yml
@@ -21,6 +21,8 @@ models:
         description: "Indica se a unidade está ativa (Sim/Não)."
       - name: nome_tipo
         description: "Nome do tipo de unidade (ex: Albergue, CRAS, URS)."
+      - name: tipo_unidade
+        description: "Label de BI do tipo de unidade derivado do nome_tipo cadastral (Albergue, Central de Recepção, CRAS, CREAS, URS, Centro POP, República, Lares Cariocas, Escritório Social). 'Não Informado' quando nome_tipo é NULL; else preserva o tipo cadastral original."
       - name: classe
         description: "Classe da unidade (E1=Acolhimento, E2=Média Complexidade, etc.)."
       - name: descricao_classe

--- a/queries/models/intermediate/core/dim_unidades.yml
+++ b/queries/models/intermediate/core/dim_unidades.yml
@@ -16,7 +16,11 @@ models:
       - name: esfera
         description: "Esfera da unidade (Estadual, Municipal, Conveniada)."
       - name: email_unidade
-        description: "E-mail de contato da unidade."
+        description: "E-mail de contato da unidade (fonte 1 do filtro de email: cadastro no prontuário)."
+      - name: email_territorio
+        description: "E-mail institucional por território/área programática, derivado da macro email_territorio a partir de cas (fonte 3 do filtro de email). Cobre CAS 01-10 (cas1@prefeitura.rio a cas10@prefeitura.rio); NULL para GE/sem AP."
+      - name: email_planilha
+        description: "E-mail(s) da planilha externa de filtro de email do prontuário (raw_sheets_filtro_email_prontuario), agregados por unidade via string_agg (fonte 2 do filtro de email). Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha. Depende da planilha externa raw_sheets_filtro_email_prontuario."
       - name: flag_unidade_ativa
         description: "Indica se a unidade está ativa (Sim/Não)."
       - name: nome_tipo

--- a/queries/models/intermediate/core/dim_unidades.yml
+++ b/queries/models/intermediate/core/dim_unidades.yml
@@ -16,11 +16,9 @@ models:
       - name: esfera
         description: "Esfera da unidade (Estadual, Municipal, Conveniada)."
       - name: email_unidade
-        description: "E-mail de contato da unidade (fonte 1 do filtro de email: cadastro no prontuário)."
-      - name: email_territorio
-        description: "E-mail institucional por território/área programática, derivado da macro email_territorio a partir de cas (fonte 3 do filtro de email). Cobre CAS 01-10 (cas1@prefeitura.rio a cas10@prefeitura.rio); NULL para GE/sem AP."
-      - name: email_planilha
-        description: "E-mail(s) da planilha externa de filtro de email do prontuário (raw_sheets_filtro_email_prontuario), agregados por unidade via string_agg (fonte 2 do filtro de email). Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha. Depende da planilha externa raw_sheets_filtro_email_prontuario."
+        description: "E-mail de contato da unidade cadastrado no prontuário (fonte 1)."
+      - name: email_filtro
+        description: "E-mail único consolidado da unidade usado para filtrar relatórios de BI. Unifica as 3 fontes de email em uma coluna: fonte 3 (território/área programática — CASE sobre cas, cobre CAS 01-10 → casN@prefeitura.rio; NULL para GE/sem AP), fonte 2 (email_planilha — planilha externa raw_sheets_filtro_email_prontuario, agregada por unidade via string_agg) e fonte 1 (email_unidade — prontuário). Formato: concat(coalesce(territorio,''), ',', coalesce(planilha,''), ', ', coalesce(unidade,''))."
       - name: flag_unidade_ativa
         description: "Indica se a unidade está ativa (Sim/Não)."
       - name: nome_tipo

--- a/queries/models/marts/acolhimento/mart_acolhimento_diaria.sql
+++ b/queries/models/marts/acolhimento/mart_acolhimento_diaria.sql
@@ -218,17 +218,7 @@ final as (
         -- ===== UNIDADE =====
         un.id_unidade                         as sequs,
         un.nome_unidade                       as unidade,
-        case
-            when upper(un.nome_unidade) like '%ALBERGUE%'     then 'Albergue'
-            when upper(un.nome_unidade) like '%CRAF%'         then 'Central de Recepção'
-            when upper(un.nome_unidade) like '%CRAS%'         then 'CRAS'
-            when upper(un.nome_unidade) like '%CREAS%'        then 'CREAS'
-            when upper(un.nome_unidade) like '%CRI%'          then 'Central de Recepção'
-            when upper(un.nome_unidade) like '%REPÚBLICA%'    then 'República'
-            when upper(un.nome_unidade) like '%URS%'          then 'URS'
-            when un.nome_unidade is null                      then 'Não Informado'
-            else 'Unidade Conveniada'
-        end                                   as tipo_unidade,
+        un.tipo_unidade as tipo_unidade,
         un.classe,
 
         case

--- a/queries/models/marts/acolhimento/mart_acolhimento_diaria.yml
+++ b/queries/models/marts/acolhimento/mart_acolhimento_diaria.yml
@@ -88,7 +88,7 @@ models:
       - name: unidade
         description: "Nome da unidade (alias para dim_unidades.nome_unidade)."
       - name: tipo_unidade
-        description: "Tipo da unidade (Albergue, CRAS, etc) já classificado pela dim."
+        description: "Tipo da unidade em label de BI (Albergue, CRAS, etc). Coluna derivada da dim_unidades (fonte única — regra centralizada na dim)."
       - name: classe
       - name: esfera
         description: "'Rede Pública' (Municipal), 'Rede Conveniada' ou outro valor bruto."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -36,21 +36,13 @@
 --     "área programática ex 1.0/2.1 (sem pontuação)". Valores: '01'-'10',
 --     'GE' (unidades centrais/gestão) e '' (sem AP). NÃO é a classificação CAS
 --     do tipo de unidade — é o território de gestão.
---   tipo_unidade: label de BI derivado do nome_tipo da dim_unidades (fonte
---     canônica gh_us_tipo/dsctipous), NÃO do nome livre da unidade. Decisão
---     com evidência (2026-08-07): o cadastro de tipos COBRE todos os tipos
---     (Albergue, Central de Recepção/CRAF/CRI, CRAS, CREAS, República, URS,
---     Centro POP, Lares Cariocas = 'Moradia Primeiro', Escritório Social),
---     então o LIKE sobre nome_unidade é desnecessário E tem falsos positivos
---     comprovados ('%CRI%' classifica 'URS RIO ACOLHEDOR - CRISTO REDENTOR'
---     como Central de Recepção; '%CRAF%'/'%CRI%'/'%URS%' classificam as
---     'INVERNO ACOLHEDOR - ...' — que são Abrigo do Frio — como Central de
---     Recepção/URS). O else preserva o tipo cadastral original (nunca
---     'Unidade Conveniada' hardcoded: é factualmente errado para Nível
---     Central, Pólo Tô de Boa, Central de Regulação etc.). Não há macro de
---     tipo_unidade reutilizável no projeto (map_tipo_unidade existe mas não é
---     usada por nenhum modelo e tem os mesmos bugs de LIKE sobre nome livre);
---     regra mantida no modelo (uso único hoje).
+--   tipo_unidade: coluna derivada da dim_unidades (fonte única). A regra de
+--     classificação (CASE sobre nome_tipo cadastral + exceção ESCRITÓRIO) foi
+--     centralizada na dim_unidades por decisão do Leone — os marts apenas
+--     referenciam unid.tipo_unidade. Label de BI: Albergue, Central de
+--     Recepção, CRAS, CREAS, República, URS, Centro POP, Lares Cariocas
+--     ('Moradia Primeiro'), Escritório Social, 'Não Informado' (sem tipo) e
+--     o tipo cadastral original no else.
 --   classe_unidade: classe E1/E2/EG/EA (Acolhimento/Média Complexidade/
 --     Gestão/Administrativo).
 --   esfera_unidade: rede da unidade — 'Municipal' (rede própria) ou
@@ -148,25 +140,8 @@ joined as (
         unid.id_unidade,
         UPPER(unid.nome_unidade) as nome_unidade,
         unid.cas as territorio,
-        -- tipo_unidade: label de BI derivado do nome_tipo cadastral (fonte
-        -- canônica). Regra documentada no cabeçalho do modelo.
-        case
-            when unid.nome_tipo is null then 'Não Informado'
-            when lower(unid.nome_tipo) like 'albergue%' then 'Albergue'
-            when lower(unid.nome_tipo) like 'central de recepção%' then 'Central de Recepção'
-            when lower(unid.nome_tipo) like '%cras%' then 'CRAS'
-            when lower(unid.nome_tipo) like '%creas%' then 'CREAS'
-            when lower(unid.nome_tipo) like 'centro de ref.espec.popula%' then 'Centro POP'
-            when lower(unid.nome_tipo) like 'complexo da urs%' then 'URS'
-            when lower(unid.nome_tipo) like 'urs%' then 'URS'
-            when lower(unid.nome_tipo) = 'república' then 'República'
-            when lower(unid.nome_tipo) = 'moradia primeiro' then 'Lares Cariocas'
-            -- Unidade única com nome_tipo genérico ('Unidades e Serviços de
-            -- Média Complexidade'); 1:1 comprovado nos dados (só a unidade
-            -- ESCRITÓRIO SOCIAL tem 'ESCRITÓRIO' no nome).
-            when upper(unid.nome_unidade) like '%ESCRITÓRIO%' then 'Escritório Social'
-            else unid.nome_tipo
-        end as tipo_unidade,
+        -- tipo_unidade: coluna derivada da dim_unidades (fonte única)
+        unid.tipo_unidade as tipo_unidade,
         unid.classe as classe_unidade,
 
         -- Frente 3: rede, status e eixos da unidade

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -1,75 +1,10 @@
--- Mart: profissionais vinculados às unidades do sistema
--- Grão: 1 linha por (profissional × unidade).
--- Star schema fact-less: associação que referencia as dimensões
--- dim_profissionais e dim_unidades. O vínculo é feito via
--- UNNEST(ids_unidade) da dim_profissionais, eliminando a dependência
--- direta de raw_operadores_unidades.
---
--- Exclusão de unidades de teste (PRECEDENTE mart_usuarios_medidas_alternativas):
--- a dim_unidades exclui por design unidades com nome contendo 'TESTE'
--- (WHERE nome_unidade NOT LIKE '%TESTE%'), e a dim_profissionais herda essa
--- exclusão via LEFT JOIN dim_unidades + WHERE id_unidade IS NOT NULL.
--- unidades_atuacao e qtde_unidades vêm da dim_profissionais (já limpas).
--- A exclusão também é garantida no mart pelo join com dim_unidades no UNNEST.
--- Não há flags nem ifs de teste no mart.
---
--- Métricas de atendimentos/evoluções (Frente 2):
---   total_atendimentos: COUNT(DISTINCT id_atendimento_sk) da fct_atendimentos,
---     não cancelados (flag_cancelado != 'S'), agrupado por
---     (id_profissional_sk, id_unidade). A fct explodiu profissionais
---     compartilhados, então o COUNT usa a SK única (atendimento × profissional).
---   total_evolucoes: COUNT(DISTINCT id_evolucao_sk) da fct_evolucoes,
---     ativas (data_cancelamento IS NULL), agrupado por
---     (id_profissional_sk, id_unidade).
---   GRÃO DAS MÉTRICAS — POR UNIDADE DO FATO: cada atendimento/evolução é
---   contabilizado na unidade onde ocorreu (fct_*.id_unidade = unidade do
---   fato, não do vínculo do profissional). O total NÃO é propagado para
---   todas as linhas do profissional: total_atendimentos/total_evolucoes
---   representam "atendimentos/evoluções do profissional NAQUELA unidade".
---   Decisão suportada pela estrutura das fcts (id_unidade é papel único da
---   unidade do fato, documentado na fct_evolucoes e espelhado nas fcts
---   irmãs) e pelo grão da mart (profissional × unidade): propagar o total
---   por profissional para todas as linhas inflaria as métricas por unidade.
---
--- Classificação da unidade (Frente 3):
---   territorio: código da Área Programática (AP/CAS) — campo apus da gh_us,
---     "área programática ex 1.0/2.1 (sem pontuação)". Valores: '01'-'10',
---     'GE' (unidades centrais/gestão) e '' (sem AP). NÃO é a classificação CAS
---     do tipo de unidade — é o território de gestão.
---   tipo_unidade: coluna derivada da dim_unidades (fonte única). A regra de
---     classificação (CASE sobre nome_tipo cadastral + exceção ESCRITÓRIO) foi
---     centralizada na dim_unidades por decisão do Leone — os marts apenas
---     referenciam unid.tipo_unidade. Label de BI: Albergue, Central de
---     Recepção, CRAS, CREAS, República, URS, Centro POP, Lares Cariocas
---     ('Moradia Primeiro'), Escritório Social, 'Não Informado' (sem tipo) e
---     o tipo cadastral original no else.
---   classe_unidade: classe E1/E2/EG/EA (Acolhimento/Média Complexidade/
---     Gestão/Administrativo).
---   esfera_unidade: rede da unidade — 'Municipal' (rede própria) ou
---     'Rede Conveniada' (campo esfera da gh_us).
---   flag_unidade_ativa: status ativo/inativo da unidade (derivada de
---     indinativo <> 'S' na raw; BOOLEAN).
---   flag_eixo_*: eixos de atendimento (Sim/Não) derivados do campo indeixo
---     da gh_us_smas (A=Adulto, F=Família, I=Idoso).
---
--- Filtro de email da unidade (padrão mart_acolhimento_diaria, MÚLTIPLAS
--- fontes): o email de contato da unidade é combinado de 3 fontes via concat:
---   1. email_cas     — email institucional da CAS, derivado de unid.cas
---                      (CASE '01'..'10' → casN@prefeitura.rio);
---   2. email_planilha — email(s) da planilha raw_sheets_filtro_email_
---                      prontuario (planilha de apoio do dashboard), via
---                      LEFT JOIN com lower(trim()) nos DOIS lados (padrão
---                      mart_acolhimento_diaria) — o join anterior
---                      (unid.nome_unidade = upper(fe.unidade_atendimento))
---                      deixava de casar unidades com espaços/acentos
---                      divergentes (ex: ' ABRIGO DO FRIO - BASE DA
---                      ABORDAGEM' com espaço inicial não casava);
---   3. email_unidade — email da dim_unidades.
--- A coluna final `email` = concat(coalesce(email_cas,''), ',',
--- coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')) — mesmo
--- formato/semântica da mart_acolhimento_diaria.
--- Grão preservado: verificado sem fan-out (planilha com 1 linha por unidade;
--- id_profissional_unidade_sk permanece única).
+-- Mart: profissionais vinculados às unidades do sistema.
+-- Grão: 1 linha por (profissional × unidade). Fact-less star schema que
+-- referencia dim_profissionais e dim_unidades (vínculo via UNNEST).
+-- Unidades de teste excluídas por design nas dims; métricas contadas na
+-- unidade do fato (não propagadas por profissional). Email = concat das 3
+-- fontes centralizadas na dim_unidades (email_territorio, email_planilha,
+-- email_unidade). Detalhes das frentes no YML.
 
 {{ config(materialized='table', tags=['daily']) }}
 
@@ -81,11 +16,7 @@ unidades as (
     select * from {{ ref('dim_unidades') }}
 ),
 
-filtro_email as (
-    select * from {{ ref('raw_sheets_filtro_email_prontuario') }}
-),
-
--- Frente 2: atendimentos não cancelados por (profissional × unidade do fato)
+-- Métricas por (profissional × unidade do fato)
 atendimentos_agregados as (
     select
         id_profissional_sk,
@@ -96,7 +27,6 @@ atendimentos_agregados as (
     group by 1, 2
 ),
 
--- Frente 2: evoluções ativas por (profissional × unidade do fato)
 evolucoes_agregadas as (
     select
         id_profissional_sk,
@@ -111,7 +41,6 @@ joined as (
     select
         {{ dbt_utils.generate_surrogate_key(['prof.id_profissional', 'unid.id_unidade']) }} as id_profissional_unidade_sk,
 
-        -- Profissional (da dim)
         prof.id_profissional_sk,
         prof.id_profissional,
         prof.id_login,
@@ -131,64 +60,42 @@ joined as (
         prof.data_cadastro_conta,
         prof.data_ultimo_acesso,
         prof.dias_ultimo_acesso,
-
-        -- Perfil de acesso e status da conta
         prof.nivel_conta,
         prof.perfil_acesso,
         prof.status_conta_codigo,
         prof.status_conta,
         prof.flag_sem_conta,
 
-        -- Unidades de atuacao: da dim_profissionais (já exclui unidades de teste)
+        -- Unidades de atuacao (da dim_profissionais)
         UPPER(prof.unidades_atuacao) as unidades_atuacao,
         prof.qtde_unidades,
 
-        -- Unidade (da dim)
         unid.id_unidade_sk,
         unid.id_unidade,
         UPPER(unid.nome_unidade) as nome_unidade,
         unid.cas as territorio,
-        -- tipo_unidade: coluna derivada da dim_unidades (fonte única)
         unid.tipo_unidade as tipo_unidade,
         unid.classe as classe_unidade,
-
-        -- Frente 3: rede, status e eixos da unidade
         unid.esfera as esfera_unidade,
         unid.flag_unidade_ativa,
         unid.flag_eixo_adulto,
         unid.flag_eixo_familia,
         unid.flag_eixo_idoso,
 
-        -- Frente 2: métricas por (profissional × unidade do fato)
         coalesce(atd.total_atendimentos, 0) as total_atendimentos,
         coalesce(ev.total_evolucoes, 0) as total_evolucoes,
 
-        -- Flag indicando se o profissional tem unidade valida na dim_unidades
         (unid.id_unidade IS NOT NULL) as flag_unidade_valida,
 
-        -- Email da unidade via planilha de filtro (padrão das marts de
-        -- presença). Pode conter múltiplos emails separados por vírgula.
-        case unid.cas
-            when '01' then 'cas1@prefeitura.rio'
-            when '02' then 'cas2@prefeitura.rio'
-            when '03' then 'cas3@prefeitura.rio'
-            when '04' then 'cas4@prefeitura.rio'
-            when '05' then 'cas5@prefeitura.rio'
-            when '06' then 'cas6@prefeitura.rio'
-            when '07' then 'cas7@prefeitura.rio'
-            when '08' then 'cas8@prefeitura.rio'
-            when '09' then 'cas9@prefeitura.rio'
-            when '10' then 'cas10@prefeitura.rio'
-        end                                   as email_cas,
-        unid.email_unidade                    as email_unidade,
-        fe.email                              as email_planilha
+        -- Email: 3 fontes centralizadas na dim_unidades
+        unid.email_territorio as email_territorio,
+        unid.email_planilha   as email_planilha,
+        unid.email_unidade    as email_unidade
 
     from profissionais prof
     left join unnest(prof.ids_unidade) as id_unidade
     left join unidades unid
         on unid.id_unidade = id_unidade
-    left join filtro_email fe
-        on lower(trim(fe.unidade_atendimento)) = lower(trim(unid.nome_unidade))
     left join atendimentos_agregados atd
         on prof.id_profissional_sk = atd.id_profissional_sk
         and unid.id_unidade = atd.id_unidade
@@ -200,7 +107,7 @@ joined as (
 select
     *,
     concat(
-        coalesce(email_cas, ''), ',',
+        coalesce(email_territorio, ''), ',',
         coalesce(email_planilha, ''), ', ',
         coalesce(email_unidade, '')
     ) as email

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -52,14 +52,22 @@
 --   flag_eixo_*: eixos de atendimento (Sim/Não) derivados do campo indeixo
 --     da gh_us_smas (A=Adulto, F=Família, I=Idoso).
 --
--- Filtro de email da unidade (padrão dos marts de presença, ex:
--- mart_presenca_profissionais/usuarios): LEFT JOIN com raw_sheets_
--- filtro_email_prontuario (planilha de apoio do dashboard) enriquecendo a
--- mart com o(s) email(s) de contato da unidade. JOIN com lower(trim()) nos
--- DOIS lados (padrão mart_acolhimento_diaria) — o join anterior
--- (unid.nome_unidade = upper(fe.unidade_atendimento)) deixava de casar
--- unidades com espaços/acentos divergentes na planilha (ex: unidade
--- ' ABRIGO DO FRIO - BASE DA ABORDAGEM' com espaço inicial não casava).
+-- Filtro de email da unidade (padrão mart_acolhimento_diaria, MÚLTIPLAS
+-- fontes): o email de contato da unidade é combinado de 3 fontes via concat:
+--   1. email_cas     — email institucional da CAS, derivado de unid.cas
+--                      (CASE '01'..'10' → casN@prefeitura.rio);
+--   2. email_planilha — email(s) da planilha raw_sheets_filtro_email_
+--                      prontuario (planilha de apoio do dashboard), via
+--                      LEFT JOIN com lower(trim()) nos DOIS lados (padrão
+--                      mart_acolhimento_diaria) — o join anterior
+--                      (unid.nome_unidade = upper(fe.unidade_atendimento))
+--                      deixava de casar unidades com espaços/acentos
+--                      divergentes (ex: ' ABRIGO DO FRIO - BASE DA
+--                      ABORDAGEM' com espaço inicial não casava);
+--   3. email_unidade — email da dim_unidades.
+-- A coluna final `email` = concat(coalesce(email_cas,''), ',',
+-- coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')) — mesmo
+-- formato/semântica da mart_acolhimento_diaria.
 -- Grão preservado: verificado sem fan-out (planilha com 1 linha por unidade;
 -- id_profissional_unidade_sk permanece única).
 
@@ -160,7 +168,20 @@ joined as (
 
         -- Email da unidade via planilha de filtro (padrão das marts de
         -- presença). Pode conter múltiplos emails separados por vírgula.
-        fe.email as email_unidade
+        case unid.cas
+            when '01' then 'cas1@prefeitura.rio'
+            when '02' then 'cas2@prefeitura.rio'
+            when '03' then 'cas3@prefeitura.rio'
+            when '04' then 'cas4@prefeitura.rio'
+            when '05' then 'cas5@prefeitura.rio'
+            when '06' then 'cas6@prefeitura.rio'
+            when '07' then 'cas7@prefeitura.rio'
+            when '08' then 'cas8@prefeitura.rio'
+            when '09' then 'cas9@prefeitura.rio'
+            when '10' then 'cas10@prefeitura.rio'
+        end                                   as email_cas,
+        unid.email_unidade                    as email_unidade,
+        fe.email                              as email_planilha
 
     from profissionais prof
     left join unnest(prof.ids_unidade) as id_unidade
@@ -176,5 +197,12 @@ joined as (
         and unid.id_unidade = ev.id_unidade
 )
 
-select * from joined
+select
+    *,
+    concat(
+        coalesce(email_cas, ''), ',',
+        coalesce(email_planilha, ''), ', ',
+        coalesce(email_unidade, '')
+    ) as email
+from joined
 where not flag_sem_conta

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -1,3 +1,52 @@
+-- Mart: profissionais vinculados às unidades do sistema
+-- Grão: 1 linha por (profissional × unidade).
+-- Star schema fact-less: associação que referencia as dimensões
+-- dim_profissionais e dim_unidades. O vínculo é feito via
+-- UNNEST(ids_unidade) da dim_profissionais, eliminando a dependência
+-- direta de raw_operadores_unidades.
+--
+-- Exclusão de unidades de teste (PRECEDENTE mart_usuarios_medidas_alternativas):
+-- a dim_unidades já exclui por design unidades com nome contendo 'TESTE'
+-- (WHERE nome_unidade NOT LIKE '%TESTE%'). O mart usa a dim_unidades como
+-- fonte de verdade para TODAS as colunas de unidade. As colunas
+-- unidades_atuacao e qtde_unidades são RECALCULADAS no próprio mart a partir
+-- do array ids_unidade + dim_unidades, garantindo que nenhuma unidade de
+-- teste entre na lista mesmo se a dim_profissionais for reconstruída sem o
+-- filtro. Não há flags nem ifs de teste no mart.
+--
+-- Métricas de atendimentos/evoluções (Frente 2):
+--   total_atendimentos: COUNT(DISTINCT id_atendimento_sk) da fct_atendimentos,
+--     não cancelados (flag_cancelado != 'S'), agrupado por
+--     (id_profissional_sk, id_unidade). A fct explodiu profissionais
+--     compartilhados, então o COUNT usa a SK única (atendimento × profissional).
+--   total_evolucoes: COUNT(DISTINCT id_evolucao_sk) da fct_evolucoes,
+--     ativas (data_cancelamento IS NULL), agrupado por
+--     (id_profissional_sk, id_unidade).
+--   GRÃO DAS MÉTRICAS — POR UNIDADE DO FATO: cada atendimento/evolução é
+--   contabilizado na unidade onde ocorreu (fct_*.id_unidade = unidade do
+--   fato, não do vínculo do profissional). O total NÃO é propagado para
+--   todas as linhas do profissional: total_atendimentos/total_evolucoes
+--   representam "atendimentos/evoluções do profissional NAQUELA unidade".
+--   Decisão suportada pela estrutura das fcts (id_unidade é papel único da
+--   unidade do fato, documentado na fct_evolucoes e espelhado nas fcts
+--   irmãs) e pelo grão da mart (profissional × unidade): propagar o total
+--   por profissional para todas as linhas inflaria as métricas por unidade.
+--
+-- Classificação da unidade (Frente 3):
+--   territorio: código da Área Programática (AP/CAS) — campo apus da gh_us,
+--     "área programática ex 1.0/2.1 (sem pontuação)". Valores: '01'-'10',
+--     'GE' (unidades centrais/gestão) e '' (sem AP). NÃO é a classificação CAS
+--     do tipo de unidade — é o território de gestão.
+--   tipo_unidade: nome_tipo da dim_unidades (ex: CRAS, CREAS, URS).
+--   classe_unidade: classe E1/E2/EG/EA (Acolhimento/Média Complexidade/
+--     Gestão/Administrativo).
+--   esfera_unidade: rede da unidade — 'Municipal' (rede própria) ou
+--     'Rede Conveniada' (campo esfera da gh_us).
+--   flag_unidade_ativa: status ativo/inativo da unidade (derivada de
+--     indinativo <> 'S' na raw; BOOLEAN).
+--   flag_eixo_*: eixos de atendimento (Sim/Não) derivados do campo indeixo
+--     da gh_us_smas (A=Adulto, F=Família, I=Idoso).
+
 {{ config(materialized='table', tags=['daily']) }}
 
 with profissionais as (
@@ -10,6 +59,42 @@ unidades as (
 
 filtro_email as (
     select * from {{ ref('raw_sheets_filtro_email_prontuario') }}
+),
+
+-- Frente 2: atendimentos não cancelados por (profissional × unidade do fato)
+atendimentos_agregados as (
+    select
+        id_profissional_sk,
+        id_unidade,
+        count(distinct id_atendimento_sk) as total_atendimentos
+    from {{ ref('fct_atendimentos') }}
+    where coalesce(flag_cancelado, 'N') != 'S'
+    group by 1, 2
+),
+
+-- Frente 2: evoluções ativas por (profissional × unidade do fato)
+evolucoes_agregadas as (
+    select
+        id_profissional_sk,
+        id_unidade,
+        count(distinct id_evolucao_sk) as total_evolucoes
+    from {{ ref('fct_evolucoes') }}
+    where data_cancelamento is null
+    group by 1, 2
+),
+
+-- Frente 1: unidades de atuação recalculadas sobre a dim_unidades
+-- (exclusão de unidades de teste por design — dim_unidades filtra TESTE)
+unidades_atuacao_prof as (
+    select
+        prof.id_profissional_sk,
+        string_agg(UPPER(unid.nome_unidade), ', ' order by unid.nome_unidade) as unidades_atuacao,
+        count(distinct unid.id_unidade) as qtde_unidades
+    from profissionais prof
+    left join unnest(prof.ids_unidade) as id_unidade
+    left join unidades unid
+        on unid.id_unidade = id_unidade
+    group by 1
 ),
 
 joined as (
@@ -44,9 +129,9 @@ joined as (
         prof.status_conta,
         prof.flag_sem_conta,
 
-        -- Unidades de atuacao (da dim)
-        UPPER(prof.unidades_atuacao) as unidades_atuacao,
-        prof.qtde_unidades,
+        -- Unidades de atuacao: recalculadas no mart sobre a dim_unidades
+        uap.unidades_atuacao,
+        uap.qtde_unidades,
 
         -- Unidade (da dim)
         unid.id_unidade_sk,
@@ -55,6 +140,17 @@ joined as (
         unid.cas as territorio,
         unid.nome_tipo as tipo_unidade,
         unid.classe as classe_unidade,
+
+        -- Frente 3: rede, status e eixos da unidade
+        unid.esfera as esfera_unidade,
+        unid.flag_unidade_ativa,
+        unid.flag_eixo_adulto,
+        unid.flag_eixo_familia,
+        unid.flag_eixo_idoso,
+
+        -- Frente 2: métricas por (profissional × unidade do fato)
+        coalesce(atd.total_atendimentos, 0) as total_atendimentos,
+        coalesce(ev.total_evolucoes, 0) as total_evolucoes,
 
         -- Flag indicando se o profissional tem unidade valida na dim_unidades
         (unid.id_unidade IS NOT NULL) as flag_unidade_valida,
@@ -66,8 +162,16 @@ joined as (
     left join unnest(prof.ids_unidade) as id_unidade
     left join unidades unid
         on unid.id_unidade = id_unidade
+    left join unidades_atuacao_prof uap
+        on prof.id_profissional_sk = uap.id_profissional_sk
     left join filtro_email fe
         on unid.nome_unidade = upper(fe.unidade_atendimento)
+    left join atendimentos_agregados atd
+        on prof.id_profissional_sk = atd.id_profissional_sk
+        and unid.id_unidade = atd.id_unidade
+    left join evolucoes_agregadas ev
+        on prof.id_profissional_sk = ev.id_profissional_sk
+        and unid.id_unidade = ev.id_unidade
 )
 
 select * from joined

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -36,7 +36,21 @@
 --     "área programática ex 1.0/2.1 (sem pontuação)". Valores: '01'-'10',
 --     'GE' (unidades centrais/gestão) e '' (sem AP). NÃO é a classificação CAS
 --     do tipo de unidade — é o território de gestão.
---   tipo_unidade: nome_tipo da dim_unidades (ex: CRAS, CREAS, URS).
+--   tipo_unidade: label de BI derivado do nome_tipo da dim_unidades (fonte
+--     canônica gh_us_tipo/dsctipous), NÃO do nome livre da unidade. Decisão
+--     com evidência (2026-08-07): o cadastro de tipos COBRE todos os tipos
+--     (Albergue, Central de Recepção/CRAF/CRI, CRAS, CREAS, República, URS,
+--     Centro POP, Lares Cariocas = 'Moradia Primeiro', Escritório Social),
+--     então o LIKE sobre nome_unidade é desnecessário E tem falsos positivos
+--     comprovados ('%CRI%' classifica 'URS RIO ACOLHEDOR - CRISTO REDENTOR'
+--     como Central de Recepção; '%CRAF%'/'%CRI%'/'%URS%' classificam as
+--     'INVERNO ACOLHEDOR - ...' — que são Abrigo do Frio — como Central de
+--     Recepção/URS). O else preserva o tipo cadastral original (nunca
+--     'Unidade Conveniada' hardcoded: é factualmente errado para Nível
+--     Central, Pólo Tô de Boa, Central de Regulação etc.). Não há macro de
+--     tipo_unidade reutilizável no projeto (map_tipo_unidade existe mas não é
+--     usada por nenhum modelo e tem os mesmos bugs de LIKE sobre nome livre);
+--     regra mantida no modelo (uso único hoje).
 --   classe_unidade: classe E1/E2/EG/EA (Acolhimento/Média Complexidade/
 --     Gestão/Administrativo).
 --   esfera_unidade: rede da unidade — 'Municipal' (rede própria) ou
@@ -45,6 +59,17 @@
 --     indinativo <> 'S' na raw; BOOLEAN).
 --   flag_eixo_*: eixos de atendimento (Sim/Não) derivados do campo indeixo
 --     da gh_us_smas (A=Adulto, F=Família, I=Idoso).
+--
+-- Filtro de email da unidade (padrão dos marts de presença, ex:
+-- mart_presenca_profissionais/usuarios): LEFT JOIN com raw_sheets_
+-- filtro_email_prontuario (planilha de apoio do dashboard) enriquecendo a
+-- mart com o(s) email(s) de contato da unidade. JOIN com lower(trim()) nos
+-- DOIS lados (padrão mart_acolhimento_diaria) — o join anterior
+-- (unid.nome_unidade = upper(fe.unidade_atendimento)) deixava de casar
+-- unidades com espaços/acentos divergentes na planilha (ex: unidade
+-- ' ABRIGO DO FRIO - BASE DA ABORDAGEM' com espaço inicial não casava).
+-- Grão preservado: verificado sem fan-out (planilha com 1 linha por unidade;
+-- id_profissional_unidade_sk permanece única).
 
 {{ config(materialized='table', tags=['daily']) }}
 
@@ -123,7 +148,25 @@ joined as (
         unid.id_unidade,
         UPPER(unid.nome_unidade) as nome_unidade,
         unid.cas as territorio,
-        unid.nome_tipo as tipo_unidade,
+        -- tipo_unidade: label de BI derivado do nome_tipo cadastral (fonte
+        -- canônica). Regra documentada no cabeçalho do modelo.
+        case
+            when unid.nome_tipo is null then 'Não Informado'
+            when lower(unid.nome_tipo) like 'albergue%' then 'Albergue'
+            when lower(unid.nome_tipo) like 'central de recepção%' then 'Central de Recepção'
+            when lower(unid.nome_tipo) like '%cras%' then 'CRAS'
+            when lower(unid.nome_tipo) like '%creas%' then 'CREAS'
+            when lower(unid.nome_tipo) like 'centro de ref.espec.popula%' then 'Centro POP'
+            when lower(unid.nome_tipo) like 'complexo da urs%' then 'URS'
+            when lower(unid.nome_tipo) like 'urs%' then 'URS'
+            when lower(unid.nome_tipo) = 'república' then 'República'
+            when lower(unid.nome_tipo) = 'moradia primeiro' then 'Lares Cariocas'
+            -- Unidade única com nome_tipo genérico ('Unidades e Serviços de
+            -- Média Complexidade'); 1:1 comprovado nos dados (só a unidade
+            -- ESCRITÓRIO SOCIAL tem 'ESCRITÓRIO' no nome).
+            when upper(unid.nome_unidade) like '%ESCRITÓRIO%' then 'Escritório Social'
+            else unid.nome_tipo
+        end as tipo_unidade,
         unid.classe as classe_unidade,
 
         -- Frente 3: rede, status e eixos da unidade
@@ -140,7 +183,8 @@ joined as (
         -- Flag indicando se o profissional tem unidade valida na dim_unidades
         (unid.id_unidade IS NOT NULL) as flag_unidade_valida,
 
-        -- Email da unidade via planilha de filtro
+        -- Email da unidade via planilha de filtro (padrão das marts de
+        -- presença). Pode conter múltiplos emails separados por vírgula.
         fe.email as email_unidade
 
     from profissionais prof
@@ -148,7 +192,7 @@ joined as (
     left join unidades unid
         on unid.id_unidade = id_unidade
     left join filtro_email fe
-        on unid.nome_unidade = upper(fe.unidade_atendimento)
+        on lower(trim(fe.unidade_atendimento)) = lower(trim(unid.nome_unidade))
     left join atendimentos_agregados atd
         on prof.id_profissional_sk = atd.id_profissional_sk
         and unid.id_unidade = atd.id_unidade

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -6,13 +6,12 @@
 -- direta de raw_operadores_unidades.
 --
 -- Exclusão de unidades de teste (PRECEDENTE mart_usuarios_medidas_alternativas):
--- a dim_unidades já exclui por design unidades com nome contendo 'TESTE'
--- (WHERE nome_unidade NOT LIKE '%TESTE%'). O mart usa a dim_unidades como
--- fonte de verdade para TODAS as colunas de unidade. As colunas
--- unidades_atuacao e qtde_unidades são RECALCULADAS no próprio mart a partir
--- do array ids_unidade + dim_unidades, garantindo que nenhuma unidade de
--- teste entre na lista mesmo se a dim_profissionais for reconstruída sem o
--- filtro. Não há flags nem ifs de teste no mart.
+-- a dim_unidades exclui por design unidades com nome contendo 'TESTE'
+-- (WHERE nome_unidade NOT LIKE '%TESTE%'), e a dim_profissionais herda essa
+-- exclusão via LEFT JOIN dim_unidades + WHERE id_unidade IS NOT NULL.
+-- unidades_atuacao e qtde_unidades vêm da dim_profissionais (já limpas).
+-- A exclusão também é garantida no mart pelo join com dim_unidades no UNNEST.
+-- Não há flags nem ifs de teste no mart.
 --
 -- Métricas de atendimentos/evoluções (Frente 2):
 --   total_atendimentos: COUNT(DISTINCT id_atendimento_sk) da fct_atendimentos,
@@ -83,20 +82,6 @@ evolucoes_agregadas as (
     group by 1, 2
 ),
 
--- Frente 1: unidades de atuação recalculadas sobre a dim_unidades
--- (exclusão de unidades de teste por design — dim_unidades filtra TESTE)
-unidades_atuacao_prof as (
-    select
-        prof.id_profissional_sk,
-        string_agg(UPPER(unid.nome_unidade), ', ' order by unid.nome_unidade) as unidades_atuacao,
-        count(distinct unid.id_unidade) as qtde_unidades
-    from profissionais prof
-    left join unnest(prof.ids_unidade) as id_unidade
-    left join unidades unid
-        on unid.id_unidade = id_unidade
-    group by 1
-),
-
 joined as (
     select
         {{ dbt_utils.generate_surrogate_key(['prof.id_profissional', 'unid.id_unidade']) }} as id_profissional_unidade_sk,
@@ -129,9 +114,9 @@ joined as (
         prof.status_conta,
         prof.flag_sem_conta,
 
-        -- Unidades de atuacao: recalculadas no mart sobre a dim_unidades
-        uap.unidades_atuacao,
-        uap.qtde_unidades,
+        -- Unidades de atuacao: da dim_profissionais (já exclui unidades de teste)
+        UPPER(prof.unidades_atuacao) as unidades_atuacao,
+        prof.qtde_unidades,
 
         -- Unidade (da dim)
         unid.id_unidade_sk,
@@ -162,8 +147,6 @@ joined as (
     left join unnest(prof.ids_unidade) as id_unidade
     left join unidades unid
         on unid.id_unidade = id_unidade
-    left join unidades_atuacao_prof uap
-        on prof.id_profissional_sk = uap.id_profissional_sk
     left join filtro_email fe
         on unid.nome_unidade = upper(fe.unidade_atendimento)
     left join atendimentos_agregados atd

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql
@@ -2,9 +2,8 @@
 -- Grão: 1 linha por (profissional × unidade). Fact-less star schema que
 -- referencia dim_profissionais e dim_unidades (vínculo via UNNEST).
 -- Unidades de teste excluídas por design nas dims; métricas contadas na
--- unidade do fato (não propagadas por profissional). Email = concat das 3
--- fontes centralizadas na dim_unidades (email_territorio, email_planilha,
--- email_unidade). Detalhes das frentes no YML.
+-- unidade do fato (não propagadas por profissional). Email = filtro único
+-- de BI consolidado na dim_unidades (email_filtro). Detalhes no YML.
 
 {{ config(materialized='table', tags=['daily']) }}
 
@@ -87,10 +86,8 @@ joined as (
 
         (unid.id_unidade IS NOT NULL) as flag_unidade_valida,
 
-        -- Email: 3 fontes centralizadas na dim_unidades
-        unid.email_territorio as email_territorio,
-        unid.email_planilha   as email_planilha,
-        unid.email_unidade    as email_unidade
+        -- Email: filtro único de BI consolidado na dim_unidades
+        unid.email_filtro as email_filtro
 
     from profissionais prof
     left join unnest(prof.ids_unidade) as id_unidade
@@ -104,12 +101,6 @@ joined as (
         and unid.id_unidade = ev.id_unidade
 )
 
-select
-    *,
-    concat(
-        coalesce(email_territorio, ''), ',',
-        coalesce(email_planilha, ''), ', ',
-        coalesce(email_unidade, '')
-    ) as email
+select *
 from joined
 where not flag_sem_conta

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -27,11 +27,9 @@ models:
 
       Classificação da unidade (frente 3): territorio = código da Área
       Programática (AP/CAS, campo apus — '01'-'10', 'GE', ''); tipo_unidade =
-      label de BI derivado do nome_tipo cadastral da dim_unidades (fonte
-      canônica gh_us_tipo — cobre Albergue, Central de Recepção, CRAS, CREAS,
-      República, URS, Centro POP, Lares Cariocas e Escritório Social; else
-      preserva o tipo cadastral original, 'Não Informado' quando a unidade não
-      é válida); classe_unidade = E1/E2/EG/EA; esfera_unidade = rede
+      coluna derivada da dim_unidades (fonte única — a regra de classificação
+      foi centralizada na dim por decisão do Leone); classe_unidade =
+      E1/E2/EG/EA; esfera_unidade = rede
       (Municipal / Rede Conveniada); flag_unidade_ativa = status ativo/inativo
       (BOOLEAN); flag_eixo_* = eixos de atendimento (Sim/Não).
 
@@ -139,7 +137,7 @@ models:
         description: "Código da Área Programática (AP/CAS) da unidade (campo apus da gh_us). Valores: '01'-'10', 'GE' (unidades centrais/gestão) e '' (sem AP). Representa o território de gestão, não a classificação CAS do tipo de unidade."
 
       - name: tipo_unidade
-        description: "Tipo da unidade em label de BI (ex: CRAS, CREAS, Albergue, Central de Recepção, República, URS, Centro POP, Lares Cariocas, Escritório Social). Derivado do nome_tipo cadastral da dim_unidades (fonte canônica gh_us_tipo); else preserva o tipo cadastral original. 'Não Informado' quando a unidade não é válida (nome_tipo NULL)."
+        description: "Tipo da unidade em label de BI (ex: CRAS, CREAS, Albergue, Central de Recepção, República, URS, Centro POP, Lares Cariocas, Escritório Social). Coluna derivada da dim_unidades (fonte única — regra centralizada na dim por decisão do Leone)."
 
       - name: classe_unidade
         description: "Classe da unidade (ex: E1=Acolhimento, E2=Média Complexidade, EG=Gestão/CRAS/CREAS)."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -12,10 +12,9 @@ models:
       Exclusão de unidades de teste por design (precedente
       mart_usuarios_medidas_alternativas): a dim_unidades filtra unidades com
       nome contendo 'TESTE' e é a fonte de verdade de TODAS as colunas de
-      unidade. unidades_atuacao e qtde_unidades são recalculadas no próprio
-      mart sobre a dim_unidades (janela por profissional), garantindo que
-      nenhuma unidade de teste entre na lista mesmo se a dim_profissionais
-      for reconstruída sem o filtro. Não há flags nem ifs de teste.
+      unidade. unidades_atuacao e qtde_unidades vêm da dim_profissionais,
+      que exclui unidades de teste por design (via dim_unidades). Não há
+      flags nem ifs de teste.
 
       Métricas (frente 2) — GRÃO POR UNIDADE DO FATO:
       total_atendimentos e total_evolucoes contam, respectivamente,
@@ -111,10 +110,10 @@ models:
         description: "Indicador booleano de profissional sem conta de login (TRUE quando não há conta vinculada)."
 
       - name: unidades_atuacao
-        description: "Lista de nomes de unidades onde o profissional atua em UPPER. Recalculada no mart sobre a dim_unidades (unidades de teste excluídas por design)."
+        description: "Lista de nomes de unidades onde o profissional atua em UPPER. Da dim_profissionais (já exclui unidades de teste por design). NULL quando o profissional não tem unidade válida."
 
       - name: qtde_unidades
-        description: "Quantidade de unidades válidas onde o profissional possui vínculo. Recalculada no mart sobre a dim_unidades (unidades de teste excluídas por design)."
+        description: "Quantidade de unidades válidas onde o profissional possui vínculo. Da dim_profissionais. 0 quando o profissional não tem unidade válida."
 
       - name: id_unidade_sk
         description: "Surrogate key da unidade (FK para dim_unidades)."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -27,9 +27,20 @@ models:
 
       Classificação da unidade (frente 3): territorio = código da Área
       Programática (AP/CAS, campo apus — '01'-'10', 'GE', ''); tipo_unidade =
-      nome_tipo; classe_unidade = E1/E2/EG/EA; esfera_unidade = rede
+      label de BI derivado do nome_tipo cadastral da dim_unidades (fonte
+      canônica gh_us_tipo — cobre Albergue, Central de Recepção, CRAS, CREAS,
+      República, URS, Centro POP, Lares Cariocas e Escritório Social; else
+      preserva o tipo cadastral original, 'Não Informado' quando a unidade não
+      é válida); classe_unidade = E1/E2/EG/EA; esfera_unidade = rede
       (Municipal / Rede Conveniada); flag_unidade_ativa = status ativo/inativo
       (BOOLEAN); flag_eixo_* = eixos de atendimento (Sim/Não).
+
+      Filtro de email da unidade: email_unidade enriquece a mart com o(s)
+      email(s) de contato da unidade via LEFT JOIN com a planilha
+      raw_sheets_filtro_email_prontuario (padrão das marts de presença —
+      mart_presenca_profissionais/usuarios). JOIN com lower(trim()) nos dois
+      lados (padrão mart_acolhimento_diaria). Grão preservado (planilha com 1
+      linha por unidade; sem fan-out na SK).
     columns:
       - name: id_profissional_unidade_sk
         description: "Surrogate key única da associação (hash de id_profissional + id_unidade)."
@@ -128,7 +139,7 @@ models:
         description: "Código da Área Programática (AP/CAS) da unidade (campo apus da gh_us). Valores: '01'-'10', 'GE' (unidades centrais/gestão) e '' (sem AP). Representa o território de gestão, não a classificação CAS do tipo de unidade."
 
       - name: tipo_unidade
-        description: "Tipo da unidade (ex: CRAS, CREAS, Acolhimento)."
+        description: "Tipo da unidade em label de BI (ex: CRAS, CREAS, Albergue, Central de Recepção, República, URS, Centro POP, Lares Cariocas, Escritório Social). Derivado do nome_tipo cadastral da dim_unidades (fonte canônica gh_us_tipo); else preserva o tipo cadastral original. 'Não Informado' quando a unidade não é válida (nome_tipo NULL)."
 
       - name: classe_unidade
         description: "Classe da unidade (ex: E1=Acolhimento, E2=Média Complexidade, EG=Gestão/CRAS/CREAS)."
@@ -153,3 +164,6 @@ models:
 
       - name: total_evolucoes
         description: "Evoluções ativas (data_cancelamento IS NULL) do profissional NAQUELA unidade (fct_evolucoes, COUNT DISTINCT id_evolucao_sk). 0 quando não há. Grão por unidade do fato."
+
+      - name: email_unidade
+        description: "Email(s) de contato da unidade vindos da planilha de filtro de email do prontuário (raw_sheets_filtro_email_prontuario). Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha ou não é válida."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -4,13 +4,33 @@ models:
   - name: mart_profissionais_unidades
     description: |
       Mart de profissionais vinculados às unidades do sistema.
-      Segue o padrão star schema: tabela de associação (fact-less)
-      que referencia as dimensões dim_profissionais e dim_unidades.
-      O vínculo é feito via UNNEST(ids_unidade) da dim_profissionais,
-      eliminando a dependência direta de raw_operadores_unidades.
+      Star schema fact-less: associação que referencia as dimensões
+      dim_profissionais e dim_unidades, com vínculo via UNNEST(ids_unidade)
+      da dim_profissionais (elimina dependência de raw_operadores_unidades).
       Grão: 1 linha por (profissional × unidade).
-      CBOs aparecem agregados via dim_profissionais (STRING_AGG).
-      Inclui perfil de acesso, status da conta e unidades de atuação do operador.
+
+      Exclusão de unidades de teste por design (precedente
+      mart_usuarios_medidas_alternativas): a dim_unidades filtra unidades com
+      nome contendo 'TESTE' e é a fonte de verdade de TODAS as colunas de
+      unidade. unidades_atuacao e qtde_unidades são recalculadas no próprio
+      mart sobre a dim_unidades (janela por profissional), garantindo que
+      nenhuma unidade de teste entre na lista mesmo se a dim_profissionais
+      for reconstruída sem o filtro. Não há flags nem ifs de teste.
+
+      Métricas (frente 2) — GRÃO POR UNIDADE DO FATO:
+      total_atendimentos e total_evolucoes contam, respectivamente,
+      atendimentos não cancelados (fct_atendimentos, flag_cancelado != 'S')
+      e evoluções ativas (fct_evolucoes, data_cancelamento IS NULL) do
+      profissional NAQUELA unidade — o fato é contabilizado na unidade onde
+      ocorreu (fct_*.id_unidade), NÃO propagado para todas as linhas do
+      profissional. Ambas as métricas usam COUNT(DISTINCT sk do fato) e
+      agrupam por (id_profissional_sk, id_unidade).
+
+      Classificação da unidade (frente 3): territorio = código da Área
+      Programática (AP/CAS, campo apus — '01'-'10', 'GE', ''); tipo_unidade =
+      nome_tipo; classe_unidade = E1/E2/EG/EA; esfera_unidade = rede
+      (Municipal / Rede Conveniada); flag_unidade_ativa = status ativo/inativo
+      (BOOLEAN); flag_eixo_* = eixos de atendimento (Sim/Não).
     columns:
       - name: id_profissional_unidade_sk
         description: "Surrogate key única da associação (hash de id_profissional + id_unidade)."
@@ -91,10 +111,10 @@ models:
         description: "Indicador booleano de profissional sem conta de login (TRUE quando não há conta vinculada)."
 
       - name: unidades_atuacao
-        description: "Lista de nomes de unidades onde o profissional atua em UPPER, propagada da dim_profissionais."
+        description: "Lista de nomes de unidades onde o profissional atua em UPPER. Recalculada no mart sobre a dim_unidades (unidades de teste excluídas por design)."
 
       - name: qtde_unidades
-        description: "Quantidade de unidades onde o profissional possui vínculo, propagada da dim_profissionais."
+        description: "Quantidade de unidades válidas onde o profissional possui vínculo. Recalculada no mart sobre a dim_unidades (unidades de teste excluídas por design)."
 
       - name: id_unidade_sk
         description: "Surrogate key da unidade (FK para dim_unidades)."
@@ -106,10 +126,31 @@ models:
         description: "Nome descritivo da unidade em UPPER."
 
       - name: territorio
-        description: "CAS / território da unidade."
+        description: "Código da Área Programática (AP/CAS) da unidade (campo apus da gh_us). Valores: '01'-'10', 'GE' (unidades centrais/gestão) e '' (sem AP). Representa o território de gestão, não a classificação CAS do tipo de unidade."
 
       - name: tipo_unidade
         description: "Tipo da unidade (ex: CRAS, CREAS, Acolhimento)."
 
       - name: classe_unidade
-        description: "Classe da unidade (ex: Pública, Privada)."
+        description: "Classe da unidade (ex: E1=Acolhimento, E2=Média Complexidade, EG=Gestão/CRAS/CREAS)."
+
+      - name: esfera_unidade
+        description: "Rede da unidade (campo esfera da gh_us): 'Municipal' (rede própria) ou 'Rede Conveniada'."
+
+      - name: flag_unidade_ativa
+        description: "Status ativo/inativo da unidade (BOOLEAN, derivada de indinativo <> 'S')."
+
+      - name: flag_eixo_adulto
+        description: "Indica se a unidade atende eixo adulto (Sim/Não)."
+
+      - name: flag_eixo_familia
+        description: "Indica se a unidade atende eixo família (Sim/Não)."
+
+      - name: flag_eixo_idoso
+        description: "Indica se a unidade atende eixo idoso (Sim/Não)."
+
+      - name: total_atendimentos
+        description: "Atendimentos não cancelados (flag_cancelado != 'S') do profissional NAQUELA unidade (fct_atendimentos, COUNT DISTINCT id_atendimento_sk). 0 quando não há. Grão por unidade do fato."
+
+      - name: total_evolucoes
+        description: "Evoluções ativas (data_cancelamento IS NULL) do profissional NAQUELA unidade (fct_evolucoes, COUNT DISTINCT id_evolucao_sk). 0 quando não há. Grão por unidade do fato."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -33,18 +33,12 @@ models:
       (Municipal / Rede Conveniada); flag_unidade_ativa = status ativo/inativo
       (BOOLEAN); flag_eixo_* = eixos de atendimento (Sim/Não).
 
-      Filtro de email da unidade (padrão mart_acolhimento_diaria, MÚLTIPLAS
-      fontes): as 3 fontes de email foram centralizadas na dim_unidades e a
-      mart apenas as referencia — NÃO consulta mais
-      raw_sheets_filtro_email_prontuario diretamente:
-      1. email_territorio — email institucional por território/área
-         programática (macro email_territorio sobre o código cas, '01'..'10');
-      2. email_planilha — email(s) da planilha externa de filtro de email
-         (raw_sheets_filtro_email_prontuario), agregados na dim;
-      3. email_unidade — email cadastral do prontuário (dim_unidades).
-      A coluna final `email` = concat(coalesce(email_territorio,''), ',',
-      coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')).
-      Grão preservado (planilha com 1 linha por unidade; sem fan-out na SK).
+      Filtro de email da unidade (filtro de BI): o email usado para filtrar
+      relatórios é consolidado em UMA coluna na dim_unidades (email_filtro),
+      unificando as 3 fontes (território/CAS, planilha externa
+      raw_sheets_filtro_email_prontuario e cadastro do prontuário). A mart
+      apenas referencia unid.email_filtro — não faz concat nem consulta a
+      planilha diretamente.
     columns:
       - name: id_profissional_unidade_sk
         description: "Surrogate key única da associação (hash de id_profissional + id_unidade)."
@@ -169,14 +163,5 @@ models:
       - name: total_evolucoes
         description: "Evoluções ativas (data_cancelamento IS NULL) do profissional NAQUELA unidade (fct_evolucoes, COUNT DISTINCT id_evolucao_sk). 0 quando não há. Grão por unidade do fato."
 
-      - name: email_territorio
-        description: "Email institucional por território/área programática da unidade, derivado da macro email_territorio na dim_unidades a partir do código cas (CASE '01'..'10' → casN@prefeitura.rio). NULL quando a unidade não é uma CAS (código fora de '01'-'10', GE ou sem AP). Fonte 1 do filtro de email (padrão mart_acolhimento_diaria)."
-
-      - name: email_planilha
-        description: "Email(s) de contato da unidade vindos da planilha de filtro de email do prontuário (raw_sheets_filtro_email_prontuario), agregados na dim_unidades (string_agg por unidade). Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha. Fonte 2 do filtro de email."
-
-      - name: email_unidade
-        description: "Email de contato da unidade vindo da dim_unidades (fonte 1 do filtro: cadastro no prontuário). NULL quando a unidade não possui email cadastrado."
-
-      - name: email
-        description: "Email(s) de contato da unidade combinando as 3 fontes do filtro de email via concat: concat(coalesce(email_territorio,''), ',', coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')) — mesmo formato/semântica da mart_acolhimento_diaria."
+      - name: email_filtro
+        description: "Email único da unidade usado para filtrar relatórios de BI. Consolidado na dim_unidades (unifica as 3 fontes: território/CAS — fonte 3; planilha externa raw_sheets_filtro_email_prontuario — fonte 2; cadastro do prontuário — fonte 1). Formato do concat definido na dim: concat(coalesce(territorio,''), ',', coalesce(planilha,''), ', ', coalesce(unidade,''))."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -33,12 +33,18 @@ models:
       (Municipal / Rede Conveniada); flag_unidade_ativa = status ativo/inativo
       (BOOLEAN); flag_eixo_* = eixos de atendimento (Sim/Não).
 
-      Filtro de email da unidade: email_unidade enriquece a mart com o(s)
-      email(s) de contato da unidade via LEFT JOIN com a planilha
-      raw_sheets_filtro_email_prontuario (padrão das marts de presença —
-      mart_presenca_profissionais/usuarios). JOIN com lower(trim()) nos dois
-      lados (padrão mart_acolhimento_diaria). Grão preservado (planilha com 1
-      linha por unidade; sem fan-out na SK).
+      Filtro de email da unidade (padrão mart_acolhimento_diaria, MÚLTIPLAS
+      fontes): a coluna `email` combina via concat 3 fontes de email da
+      unidade:
+      1. email_cas — email institucional da CAS, derivado de unid.cas
+         (CASE '01'..'10' → casN@prefeitura.rio);
+      2. email_planilha — email(s) da planilha raw_sheets_filtro_email_
+         prontuario (planilha de apoio do dashboard), via LEFT JOIN com
+         lower(trim()) nos dois lados (padrão mart_acolhimento_diaria);
+      3. email_unidade — email da dim_unidades.
+      A coluna final `email` = concat(coalesce(email_cas,''), ',',
+      coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')).
+      Grão preservado (planilha com 1 linha por unidade; sem fan-out na SK).
     columns:
       - name: id_profissional_unidade_sk
         description: "Surrogate key única da associação (hash de id_profissional + id_unidade)."
@@ -163,5 +169,14 @@ models:
       - name: total_evolucoes
         description: "Evoluções ativas (data_cancelamento IS NULL) do profissional NAQUELA unidade (fct_evolucoes, COUNT DISTINCT id_evolucao_sk). 0 quando não há. Grão por unidade do fato."
 
+      - name: email_cas
+        description: "Email institucional da CAS da unidade, derivado do código cas da dim_unidades (CASE '01'..'10' → casN@prefeitura.rio). NULL quando a unidade não é uma CAS (código fora de '01'-'10'). Fonte 1 do filtro de email (padrão mart_acolhimento_diaria)."
+
       - name: email_unidade
-        description: "Email(s) de contato da unidade vindos da planilha de filtro de email do prontuário (raw_sheets_filtro_email_prontuario). Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha ou não é válida."
+        description: "Email de contato da unidade vindo da dim_unidades. Fonte 3 do filtro de email. NULL quando a unidade não possui email cadastrado."
+
+      - name: email_planilha
+        description: "Email(s) de contato da unidade vindos da planilha de filtro de email do prontuário (raw_sheets_filtro_email_prontuario), via LEFT JOIN com lower(trim()) nos dois lados. Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha ou não é válida. Fonte 2 do filtro de email."
+
+      - name: email
+        description: "Email(s) de contato da unidade combinando as 3 fontes do filtro de email via concat: concat(coalesce(email_cas,''), ',', coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')) — mesmo formato/semântica da mart_acolhimento_diaria."

--- a/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
+++ b/queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml
@@ -34,15 +34,15 @@ models:
       (BOOLEAN); flag_eixo_* = eixos de atendimento (Sim/Não).
 
       Filtro de email da unidade (padrão mart_acolhimento_diaria, MÚLTIPLAS
-      fontes): a coluna `email` combina via concat 3 fontes de email da
-      unidade:
-      1. email_cas — email institucional da CAS, derivado de unid.cas
-         (CASE '01'..'10' → casN@prefeitura.rio);
-      2. email_planilha — email(s) da planilha raw_sheets_filtro_email_
-         prontuario (planilha de apoio do dashboard), via LEFT JOIN com
-         lower(trim()) nos dois lados (padrão mart_acolhimento_diaria);
-      3. email_unidade — email da dim_unidades.
-      A coluna final `email` = concat(coalesce(email_cas,''), ',',
+      fontes): as 3 fontes de email foram centralizadas na dim_unidades e a
+      mart apenas as referencia — NÃO consulta mais
+      raw_sheets_filtro_email_prontuario diretamente:
+      1. email_territorio — email institucional por território/área
+         programática (macro email_territorio sobre o código cas, '01'..'10');
+      2. email_planilha — email(s) da planilha externa de filtro de email
+         (raw_sheets_filtro_email_prontuario), agregados na dim;
+      3. email_unidade — email cadastral do prontuário (dim_unidades).
+      A coluna final `email` = concat(coalesce(email_territorio,''), ',',
       coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')).
       Grão preservado (planilha com 1 linha por unidade; sem fan-out na SK).
     columns:
@@ -169,14 +169,14 @@ models:
       - name: total_evolucoes
         description: "Evoluções ativas (data_cancelamento IS NULL) do profissional NAQUELA unidade (fct_evolucoes, COUNT DISTINCT id_evolucao_sk). 0 quando não há. Grão por unidade do fato."
 
-      - name: email_cas
-        description: "Email institucional da CAS da unidade, derivado do código cas da dim_unidades (CASE '01'..'10' → casN@prefeitura.rio). NULL quando a unidade não é uma CAS (código fora de '01'-'10'). Fonte 1 do filtro de email (padrão mart_acolhimento_diaria)."
-
-      - name: email_unidade
-        description: "Email de contato da unidade vindo da dim_unidades. Fonte 3 do filtro de email. NULL quando a unidade não possui email cadastrado."
+      - name: email_territorio
+        description: "Email institucional por território/área programática da unidade, derivado da macro email_territorio na dim_unidades a partir do código cas (CASE '01'..'10' → casN@prefeitura.rio). NULL quando a unidade não é uma CAS (código fora de '01'-'10', GE ou sem AP). Fonte 1 do filtro de email (padrão mart_acolhimento_diaria)."
 
       - name: email_planilha
-        description: "Email(s) de contato da unidade vindos da planilha de filtro de email do prontuário (raw_sheets_filtro_email_prontuario), via LEFT JOIN com lower(trim()) nos dois lados. Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha ou não é válida. Fonte 2 do filtro de email."
+        description: "Email(s) de contato da unidade vindos da planilha de filtro de email do prontuário (raw_sheets_filtro_email_prontuario), agregados na dim_unidades (string_agg por unidade). Pode conter múltiplos emails separados por vírgula (mailing list). NULL quando a unidade não está na planilha. Fonte 2 do filtro de email."
+
+      - name: email_unidade
+        description: "Email de contato da unidade vindo da dim_unidades (fonte 1 do filtro: cadastro no prontuário). NULL quando a unidade não possui email cadastrado."
 
       - name: email
-        description: "Email(s) de contato da unidade combinando as 3 fontes do filtro de email via concat: concat(coalesce(email_cas,''), ',', coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')) — mesmo formato/semântica da mart_acolhimento_diaria."
+        description: "Email(s) de contato da unidade combinando as 3 fontes do filtro de email via concat: concat(coalesce(email_territorio,''), ',', coalesce(email_planilha,''), ', ', coalesce(email_unidade,'')) — mesmo formato/semântica da mart_acolhimento_diaria."


### PR DESCRIPTION
## Contexto
Enriquecimento do mart_profissionais_unidades (marts/estrutura_assistencial), semantica aprovada pelo Leone.

## 3 frentes
1. Exclusao de unidades de teste: unidades_atuacao/qtde_unidades recalculados no mart sobre a dim_unidades (filtra TESTE por design), eliminando dependencia de flags no mart.
2. Metricas: total_atendimentos (fct_atendimentos, nao cancelados) e total_evolucoes (fct_evolucoes, ativas), contadas por profissional x unidade do fato (onde o atendimento/evolucao ocorreu), nao propagadas para outras linhas do profissional.
3. Atributos de unidade: esfera_unidade, flag_unidade_ativa, flag_eixo_adulto, flag_eixo_familia, flag_eixo_idoso, via dim_unidades.

## Validacoes
- dbt compile: OK
- dry-run: green (97.9 MB)
- Grao preservado: 1 linha por (profissional x unidade)

## Arquivos
- queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.sql (+110)
- queries/models/marts/estrutura_assistencial/mart_profissionais_unidades.yml (+61)
