### PR TITLE
chore(meta): remove tag daily da mart_meta_acolhimento (agendamento manual)

### DIFF
--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -23,9 +23,6 @@ models:
       atividades:
         +tags: ["daily"]
 
-      acolhimento:
-        +tags: ["daily"]
-
       poc_paif:
         +materialized: table
         +schema: "{{ 'marts' if target.name == 'prod' else 'relatorio' }}"

--- a/queries/models/marts/acolhimento/mart_acolhimento_diaria.sql
+++ b/queries/models/marts/acolhimento/mart_acolhimento_diaria.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'table',
-    schema = 'alta_complexidade'
+    schema = 'alta_complexidade',
+    tags = ['daily']
 ) }}
 
 -- Ocupação diária dos acolhimentos institucionais.


### PR DESCRIPTION
## Motivo

A `mart_meta_acolhimento` (snapshot de apuração de meta) não precisa rodar todo dia — o Leone decidiu que o snapshot passa a ser gerado manualmente quando necessário. O build diário (`+tag:daily` via Prefect) continua rodando a `mart_acolhimento_diaria` normalmente.

## Mudanças

- `queries/dbt_project.yml`: remove `+tags: [daily]` do diretório `marts/acolhimento`
- `queries/models/marts/acolhimento/mart_acolhimento_diaria.sql`: tag `daily` movida para o `config` do modelo (padrão do projeto, ex: `mart_profissionais_unidades`)

## Efeito

- `mart_acolhimento_diaria` continua no build diário (`tag:daily`)
- `mart_meta_acolhimento` sai do build diário; snapshot fica congelado na última `data_particao`
- Rodar manualmente quando precisar: `dbt build --select mart_meta_acolhimento`

## Validação

- `dbt parse` OK (0 erros)
- `dbt ls --select tag:daily` confirma: diaria presente, meta ausente
- `dbt compile --select mart_meta_acolhimento` OK