### PR TITLE
fix(fct_atendimentos): deduplica explode de profissionais compartilhados

### DIFF
--- a/queries/models/intermediate/core/fct_atendimentos.sql
+++ b/queries/models/intermediate/core/fct_atendimentos.sql
@@ -70,7 +70,7 @@ uniao_atendimentos as (
         id_atendimento,
         id_unidade,
         id_usuario,
-        safe_cast(trim(regexp_replace(prof_id, r'^0+', '')) as int64) as id_profissional,
+        safe_cast(trim(prof_id) as int64) as id_profissional,
         id_tipo_atendimento,
         data_atendimento,
         hora_atendimento,
@@ -78,8 +78,12 @@ uniao_atendimentos as (
         flag_cancelado,
         id_login_cadastro
     from uniao_atendimentos_base,
-    UNNEST(SPLIT(id_profissional_compartilhado)) AS prof_id
-    WHERE prof_id != ''
+    UNNEST(ARRAY(
+        SELECT DISTINCT trim(regexp_replace(x, r'^0+', ''))
+        FROM UNNEST(SPLIT(uniao_atendimentos_base.id_profissional_compartilhado)) x
+        WHERE x != ''
+    )) AS prof_id
+    WHERE safe_cast(trim(prof_id) as int64) != uniao_atendimentos_base.id_profissional
 ),
 
 operadores as (


### PR DESCRIPTION
## Contexto

O run manual pós-deploy do `dbt-transform-prod` falhou com `unique_fct_atendimentos_id_atendimento_sk` (1528 duplicados). O teste existe desde maio mas nunca rodava — o PR #74 fez o `mart_profissionais_unidades` referenciar `fct_atendimentos`, puxando-o para o `+tag:daily`.

## Causa raiz

O explode de `id_profissional_compartilhado` (UNNEST) gerava linhas duplicadas do mesmo `id_atendimento_sk` (hash de id_atendimento_modulo + id_profissional):

1. **Profissional principal tambem na lista** (1522 casos): ex. `id_profissional=1320` + `compartilhado="1320"`
2. **Repeticao com/sem zero a esquerda** (6 casos): `compartilhado="766,0766"` / `"709,0709"`
3. **Tokens invalidos** (13 casos): `"25.7"`, `"025."` viram NULL no cast

## Fix

- Dedup **normalizado** da lista no UNNEST (remove zeros a esquerda antes de deduplicar) — resolve os 6 casos de `"766,0766"`
- `WHERE safe_cast(trim(prof_id) as int64) != id_profissional` — exclui o profissional principal da propria lista (1522) e filtra tokens invalidos (13)

Sem qualify no final; filtro localizado no explode.

## Validacao (BigQuery prod, simulacao do modelo com o fix)

- Duplicatas restantes: **0** (era 1528)
- Pares unicos antes: 828.589 · depois: 828.576 (diferenca de 13 = tokens invalidos removidos)
- Pares unicos legitimos perdidos: **0**

`dbt parse` OK (mesmo check do CI).