### PR TITLE
fix(meta-ar-cpf): conversao de data seletiva por tipo de campo no applyEdits

### DIFF
--- a/pipelines/arcgis/primeira_infancia_carioca/tasks.py
+++ b/pipelines/arcgis/primeira_infancia_carioca/tasks.py
@@ -10,17 +10,28 @@ from pipelines.arcgis.constants import settings
 
 # Padrão ISO de data pura (YYYY-MM-DD) — convertida para epoch ms
 # porque campos Date clássicos do ArcGIS rejeitam string (esperam timestamp).
+# Campos DateOnly aceitam string ISO e REJEITAM epoch ms — por isso a conversão
+# é seletiva por nome de coluna.
 _ISO_DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 
+# Colunas da camada meta_acordo_resultados_cpf cujo tipo no ArcGIS é Date clássico
+# (esriFieldTypeDate). Somente estas recebem epoch ms.
+_DATE_CLASSIC_COLUMNS = {
+    'data_entrada',
+    'data_saida',
+    'nascimento_data',
+}
 
-def _to_arcgis_value(value):
+
+def _to_arcgis_value(col_name, value):
     """Converte valores para o formato aceito pelo applyEdits do ArcGIS.
-    Strings ISO YYYY-MM-DD → epoch ms (campos Date clássicos).
+    Campos Date clássicos (esriFieldTypeDate): string ISO YYYY-MM-DD → epoch ms.
+    Campos DateOnly (esriFieldTypeDateOnly): mantém string (rejeita epoch ms).
     """
     if value is None:
         return None
     s = str(value).strip()
-    if _ISO_DATE_RE.match(s):
+    if col_name in _DATE_CLASSIC_COLUMNS and _ISO_DATE_RE.match(s):
         try:
             dt = datetime.strptime(s, '%Y-%m-%d')
             return int(dt.timestamp() * 1000)
@@ -65,7 +76,7 @@ def apply_arcgis_feedback(
             if col.lower() == "objectid":
                 attributes["objectid"] = int(value)
             else:
-                attributes[col] = _to_arcgis_value(clean_value)
+                attributes[col] = _to_arcgis_value(col, clean_value)
         updates.append({"attributes": attributes})
 
     batch_size = 100


### PR DESCRIPTION
## Fix
O `apply_arcgis_feedback` converte TODAS as datas ISO para epoch ms, mas a camada tem 2 tipos de campo:
- `esriFieldTypeDate` (clássico): aceita epoch ms, rejeita string → convertidas
- `esriFieldTypeDateOnly`: aceita string, rejeita epoch ms → mantém string

A conversão agora é **seletiva por nome de coluna** (`data_entrada`, `data_saida`, `nascimento_data` → epoch ms; demais datas → string).

## Contexto
Campos `data_entrada`, `data_saida`, `nascimento_data` foram recriados como Date clássico (para aparecer no Experience Builder). As outras datas (`protocolo_data_referencia`, `data_atualizacao_cadun`, `data_particao_cadun`) continuam DateOnly.

## Testado
Payload com as 6 datas (3 epoch ms + 3 string) → `success: true` no applyEdits.