### PR TITLE
fix(meta-ar-cpf): converte epoch ms do ArcGIS para ISO date no delta VIEW

### DIFF
--- a/queries/models/old_architecture/pic/meta_ar_cpf/delta_feedback_meta_ar_cpf.sql
+++ b/queries/models/old_architecture/pic/meta_ar_cpf/delta_feedback_meta_ar_cpf.sql
@@ -46,7 +46,13 @@ WITH
     ),
 
     atual AS (
-        SELECT *
+        SELECT
+            * EXCEPT(data_entrada, data_saida, nascimento_data),
+            -- Campos Date clássicos (esriFieldTypeDate): o ArcGIS devolve epoch ms
+            -- (ex: 1786579200000.0). Converte para ISO date para comparar com o BQ.
+            CAST(FORMAT_DATE('%Y-%m-%d', DATE(TIMESTAMP_MILLIS(SAFE_CAST(REGEXP_REPLACE(data_entrada, r'\.0$', '') AS INT64)))) AS STRING) AS data_entrada,
+            CAST(FORMAT_DATE('%Y-%m-%d', DATE(TIMESTAMP_MILLIS(SAFE_CAST(REGEXP_REPLACE(data_saida, r'\.0$', '') AS INT64)))) AS STRING) AS data_saida,
+            CAST(FORMAT_DATE('%Y-%m-%d', DATE(TIMESTAMP_MILLIS(SAFE_CAST(REGEXP_REPLACE(nascimento_data, r'\.0$', '') AS INT64)))) AS STRING) AS nascimento_data
         FROM {{ source('arcgis_raw', 'meta_ar_cpf_raw') }}
     )
 


### PR DESCRIPTION
## Fix
Campos Date clássicos (`data_entrada`, `data_saida`, `nascimento_data`) foram recriados no ArcGIS — o extract agora devolve **epoch ms** (`1786579200000.0`) em vez de string ISO. O delta VIEW comparava ISO (BQ) vs epoch ms (ArcGIS) → diferença eterna → delta nunca zerava.

A CTE `atual` agora converte os 3 campos de epoch ms → ISO date (`%Y-%m-%d`) antes da comparação.