### PR TITLE
feat(meta-ar-cpf): tabela dev particionada por data_particao (snapshot por rodada)

### DIFF
--- a/pipelines/arcgis/primeira_infancia_carioca/meta_ar_cpf/tasks.py
+++ b/pipelines/arcgis/primeira_infancia_carioca/meta_ar_cpf/tasks.py
@@ -50,10 +50,10 @@ def apply_arcgis_adds(item_id: str, layer_idx: int = 0):
     # 1. Garantir que crosswalk existe
     ensure_crosswalk_table()
 
-    # 2. Buscar pessoas novas (monitoradas, sem crosswalk)
+    # 2. Buscar pessoas novas (monitoradas na última partição, sem crosswalk)
     query = f"""
         SELECT dev.* FROM `{dev_table}` dev
-        WHERE dev.data_saida IS NULL
+        WHERE dev.data_particao = (SELECT MAX(data_particao) FROM `{dev_table}`)
           AND NOT EXISTS (
             SELECT 1 FROM `{cw_table}` cw
             WHERE cw.id_membro_familia = dev.id_membro_familia
@@ -79,7 +79,8 @@ def apply_arcgis_adds(item_id: str, layer_idx: int = 0):
         for col in row.index:
             value = row[col]
             # Tratar nulos e valores especiais (mesmo padrão do apply_arcgis_feedback)
-            if col.lower() == "objectid":
+            # Colunas internas do BQ que não existem no layer ArcGIS:
+            if col.lower() in ("objectid", "data_particao"):
                 continue
             # Converte date/datetime para string ISO (json.dumps não serializa date nativo)
             if hasattr(value, 'isoformat'):
@@ -158,14 +159,14 @@ def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
     dev_table = f"{project}.{DATASET}.{DEV_TABLE_NAME}"
     cw_table = f"{project}.{DATASET}.{CW_TABLE_NAME}"
 
-    # 1. Buscar inativos (na crosswalk mas sem data_saida NULL na _dev)
+    # 1. Buscar inativos (na crosswalk mas sem registro na última partição da _dev)
     query = f"""
         SELECT cw.id_membro_familia, cw.objectid_arcgis
         FROM `{cw_table}` cw
         WHERE NOT EXISTS (
             SELECT 1 FROM `{dev_table}` dev
             WHERE dev.id_membro_familia = cw.id_membro_familia
-              AND dev.data_saida IS NULL
+              AND dev.data_particao = (SELECT MAX(data_particao) FROM `{dev_table}`)
         )
     """
     rows = client.query(query).to_dataframe()

--- a/pipelines/arcgis/primeira_infancia_carioca/meta_ar_cpf/tasks.py
+++ b/pipelines/arcgis/primeira_infancia_carioca/meta_ar_cpf/tasks.py
@@ -2,8 +2,10 @@ import prefect
 from prefect import task
 import requests
 import json
+import pandas as pd
 from pipelines.arcgis.utils import _get_arcgis_token, resolve_arcgis_url, bq_client
 from pipelines.arcgis.constants import settings
+from pipelines.arcgis.primeira_infancia_carioca.tasks import _to_arcgis_value
 
 # Resolve dataset e nomes de tabela por ambiente (MODE)
 IS_PROD = settings.GCP_PROJECT == "rj-smas"
@@ -151,7 +153,9 @@ def apply_arcgis_adds(item_id: str, layer_idx: int = 0):
 def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
     """
     Marca status_monitoramento_cpf='inativo' no ArcGIS para pessoas que estão
-    na crosswalk mas não aparecem mais como monitoradas (data_saida preenchida) na _dev.
+    na crosswalk mas não aparecem mais na última partição da _dev.
+    Grava também data_saida = última partição em que a pessoa apareceu
+    (ou data da rodada, se nunca apareceu na _dev).
     """
     logger = prefect.get_run_logger()
     client = bq_client()
@@ -161,7 +165,11 @@ def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
 
     # 1. Buscar inativos (na crosswalk mas sem registro na última partição da _dev)
     query = f"""
-        SELECT cw.id_membro_familia, cw.objectid_arcgis
+        SELECT cw.id_membro_familia, cw.objectid_arcgis,
+               COALESCE(
+                 (SELECT MAX(dev2.data_particao) FROM `{dev_table}` dev2
+                  WHERE dev2.id_membro_familia = cw.id_membro_familia),
+                 CURRENT_DATE('America/Sao_Paulo')) AS data_saida
         FROM `{cw_table}` cw
         WHERE NOT EXISTS (
             SELECT 1 FROM `{dev_table}` dev
@@ -182,13 +190,15 @@ def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
     token = _get_arcgis_token()
     edits_url = f"{service_url}/applyEdits"
 
-    # 3. Montar payload (só objectid + status_monitoramento_cpf)
+    # 3. Montar payload (objectid + status_monitoramento_cpf + data_saida)
     updates = []
     for _, row in rows.iterrows():
+        data_saida_iso = pd.Timestamp(row["data_saida"]).strftime("%Y-%m-%d")
         updates.append({
             "attributes": {
                 "objectid": int(row["objectid_arcgis"]),
                 "status_monitoramento_cpf": "inativo",
+                "data_saida": _to_arcgis_value("data_saida", data_saida_iso),
             }
         })
 

--- a/pipelines/arcgis/primeira_infancia_carioca/meta_ar_cpf/tasks.py
+++ b/pipelines/arcgis/primeira_infancia_carioca/meta_ar_cpf/tasks.py
@@ -154,8 +154,9 @@ def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
     """
     Marca status_monitoramento_cpf='inativo' no ArcGIS para pessoas que estão
     na crosswalk mas não aparecem mais na última partição da _dev.
-    Grava também data_saida = última partição em que a pessoa apareceu
-    (ou data da rodada, se nunca apareceu na _dev).
+    Grava também data_saida = última partição em que a pessoa apareceu na _dev
+    (somente quando há histórico; sem fallback para a data da rodada, para não
+    "flutuar" o data_saida a cada execução).
     """
     logger = prefect.get_run_logger()
     client = bq_client()
@@ -166,10 +167,8 @@ def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
     # 1. Buscar inativos (na crosswalk mas sem registro na última partição da _dev)
     query = f"""
         SELECT cw.id_membro_familia, cw.objectid_arcgis,
-               COALESCE(
-                 (SELECT MAX(dev2.data_particao) FROM `{dev_table}` dev2
-                  WHERE dev2.id_membro_familia = cw.id_membro_familia),
-                 CURRENT_DATE('America/Sao_Paulo')) AS data_saida
+               (SELECT MAX(dev2.data_particao) FROM `{dev_table}` dev2
+                WHERE dev2.id_membro_familia = cw.id_membro_familia) AS data_saida
         FROM `{cw_table}` cw
         WHERE NOT EXISTS (
             SELECT 1 FROM `{dev_table}` dev
@@ -190,17 +189,17 @@ def apply_arcgis_status_sync(item_id: str, layer_idx: int = 0):
     token = _get_arcgis_token()
     edits_url = f"{service_url}/applyEdits"
 
-    # 3. Montar payload (objectid + status_monitoramento_cpf + data_saida)
+    # 3. Montar payload (objectid + status_monitoramento_cpf + data_saida quando houver histórico)
     updates = []
     for _, row in rows.iterrows():
-        data_saida_iso = pd.Timestamp(row["data_saida"]).strftime("%Y-%m-%d")
-        updates.append({
-            "attributes": {
-                "objectid": int(row["objectid_arcgis"]),
-                "status_monitoramento_cpf": "inativo",
-                "data_saida": _to_arcgis_value("data_saida", data_saida_iso),
-            }
-        })
+        attrs = {
+            "objectid": int(row["objectid_arcgis"]),
+            "status_monitoramento_cpf": "inativo",
+        }
+        if not pd.isna(row["data_saida"]):
+            data_saida_iso = pd.Timestamp(row["data_saida"]).strftime("%Y-%m-%d")
+            attrs["data_saida"] = _to_arcgis_value("data_saida", data_saida_iso)
+        updates.append({"attributes": attrs})
 
     # 4. Enviar
     batch_size = 100

--- a/queries/macros/meta_ar_cpf/obter_ultima_particao_meta_ar_cpf.sql
+++ b/queries/macros/meta_ar_cpf/obter_ultima_particao_meta_ar_cpf.sql
@@ -1,0 +1,7 @@
+-- Macro da última partição do meta_ar_cpf (padrão cadunico/filtro_particao_cadunico).
+-- Retorna a data da partição mais recente da tabela _dev informada.
+-- Uso: {{ obter_ultima_particao_meta_ar_cpf('rj-smas.pequenos_cariocas.meta_acordo_resultados_cpf') }}
+{% macro obter_ultima_particao_meta_ar_cpf(tabela) %}
+    {%- set m = run_query("select max(data_particao) from `" ~ tabela ~ "`").columns[0].values()[0] if execute else none -%}
+    {%- do return(m) -%}
+{% endmacro %}

--- a/queries/models/old_architecture/pic/meta_ar_cpf/delta_feedback_meta_ar_cpf.sql
+++ b/queries/models/old_architecture/pic/meta_ar_cpf/delta_feedback_meta_ar_cpf.sql
@@ -42,7 +42,7 @@ WITH
         FROM {{ cw_table }} cw
         JOIN {{ dev_table }} dev
           ON cw.id_membro_familia = dev.id_membro_familia
-        WHERE dev.data_saida IS NULL
+        WHERE dev.data_particao = (SELECT MAX(data_particao) FROM {{ dev_table }})
     ),
 
     atual AS (


### PR DESCRIPTION
## Objetivo
Atender pedido da gestão: a tabela `meta_acordo_resultados_cpf` passa de SCD2 leve (1 linha/pessoa, sem partição) para **snapshot completo por rodada, particionada por `data_particao`** (data da rodada, semântica CadÚnico). Todas as partições empilhadas; todo o processo lê **sempre a última partição** (`MAX(data_particao)`).

## Mudanças

| Arquivo | Mudança |
|---|---|
| `delta_feedback_meta_ar_cpf.sql` | `calculado` filtra `dev.data_particao = (SELECT MAX(...))` em vez de `data_saida IS NULL` |
| `tasks.py` | `apply_arcgis_adds` e `apply_arcgis_status_sync` leem a última partição; `data_particao` excluída do payload ArcGIS (campo não existe no layer) |
| `macros/meta_ar_cpf/obter_ultima_particao_meta_ar_cpf.sql` | Macro da última partição (padrão `cadunico/filtro_particao_cadunico`) |

## Seed/incremental (sandbox, fora do git)
`/root/sandbox/meta_ar_cpf_dev/`: `fonte_base.sql`/`incremental.sql` migrados para `data_particao` + snapshot por rodada (DELETE da partição do dia + INSERT completo; `data_entrada` = MIN histórico).

## Validação (dev)
- Tabela dev recriada particionada (DAY): 1 partição `2026-08-11`, 832 linhas
- Mecânica testada: 2 partições empilhadas (08-11=832, 08-12=830), foto atual = MAX, idempotência (DELETE+INSERT) OK
- Delta VIEW novo compilado e materializado no dev: 832 registros (crosswalk=832 casados com última partição)
- Syntax Python OK